### PR TITLE
test: add postflight --apply --dry-run snapshot coverage

### DIFF
--- a/tests/cli-postflight.test.ts
+++ b/tests/cli-postflight.test.ts
@@ -256,4 +256,79 @@ describe.sequential("cli postflight --apply", () => {
     expect(execaMock).toHaveBeenNthCalledWith(2, "gh", ["pr", "view", "7", "--json", "body,url"], { stdio: "pipe" });
     expect(process.exitCode).toBeUndefined();
   });
+
+  it("prints a deterministic dry-run command plan without executing gh", async () => {
+    const postflightPath = path.join(tempDir, "dry-run-postflight.json");
+    writeFileSync(
+      postflightPath,
+      JSON.stringify(
+        {
+          version: 1,
+          meta: {
+            timestamp: "2026-02-13T00:00:00.000Z",
+            actor: "agent",
+            mode: "cli",
+          },
+          work: {
+            issue_id: 2,
+            branch: "issue-2-example",
+            base_branch: "main",
+          },
+          checks: {
+            tests: {
+              ran: true,
+              result: "pass",
+            },
+          },
+          tracker_updates: [
+            { type: "comment_append", body: "Dry-run comment." },
+            { type: "label_add", label: "status:in-review" },
+            { type: "label_remove", label: "status:backlog" },
+            { type: "status", to: "status:done" },
+            { type: "link_pr", pr_number: 7 },
+            { type: "issue_close", body: "Dry-run close." },
+          ],
+          next_actions: ["Merge branch."],
+          risks: {
+            summary: "Low risk.",
+            rollback_plan: "Revert commit.",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    const logs: string[] = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--dry-run"]);
+
+    expect(execaMock).not.toHaveBeenCalled();
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "postflight: OK",
+        "issue: 2 | branch: issue-2-example",
+        "
+      Applying updates:",
+        "$ gh issue comment 2 --body Dry-run comment.",
+        "$ gh issue edit 2 --add-label status:in-review",
+        "$ gh issue edit 2 --remove-label status:backlog",
+        "$ gh issue edit 2 --add-label status:done",
+        "$ gh issue comment 2 --body Linked PR: #7",
+        "$ gh issue close 2 --comment Dry-run close.",
+        "$ gh pr view 7 --json body,url",
+        "$ gh pr edit 7 --body <existing-body>\\n\\nFixes #2",
+        "
+      postflight --apply: DONE",
+      ]
+    `);
+    expect(process.exitCode).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- add CLI test for postflight apply dry-run path
- capture deterministic command plan output with inline snapshot
- verify no gh commands execute when --dry-run is enabled

## Validation
- pnpm test
- pnpm build

Closes #5