### PR TITLE
docs: add README with canonical CLI workflow and dev install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,121 @@
+# vibe-backlog
+
+CLI-first project workflow for solo builders using GitHub issues + postflight artifacts.
+
+This project has two usage modes:
+
+- Canonical and reproducible commands (recommended for agents): `pnpm build && node dist/cli.cjs ...`
+- Convenience commands (for shorter typing): global `vibe` via `pnpm link --global` + `hash -r`
+
+Do not rely only on the global bin path. Always keep the canonical path available.
+
+## 0) Requirements
+
+```bash
+pnpm -v
+gh auth status
+git --version
+```
+
+## 1) Create a new repo (local + private remote)
+
+```bash
+# 1) create folder and git
+mkdir my-project && cd my-project
+git init -b main
+
+# 2) minimal gitignore
+cat > .gitignore <<'EOF'
+node_modules
+dist
+.DS_Store
+*.log
+.vibe/runtime
+.vibe/artifacts
+EOF
+
+# 3) first commit
+git add .
+git commit -m "chore: init"
+
+# 4) create private remote and push
+git remote -v
+# if empty:
+gh repo create <NAME> --private --source=. --remote=origin --push
+```
+
+## 2) Install vibe-backlog (from the vibe-backlog repo, dev mode)
+
+This is for developing `vibe-backlog` from source.
+
+```bash
+# inside vibe-backlog repo
+pnpm install
+pnpm test
+pnpm build
+
+# option A (recommended for agents / reproducible)
+node dist/cli.cjs --help
+
+# option B (convenience: global "vibe" command)
+pnpm link --global
+hash -r
+vibe --help
+```
+
+## 3) Use vibe-backlog in another repo (with global bin already linked)
+
+```bash
+cd /path/to/another-repo
+vibe preflight
+vibe postflight
+vibe postflight --apply --dry-run
+```
+
+If you want to avoid global bin drift, run from the vibe-backlog repo path:
+
+```bash
+node /path/to/vibe-backlog/dist/cli.cjs preflight
+```
+
+## 4) Recommended workflow (Issue-first + Postflight)
+
+```bash
+# 1) inspect repo + issue state
+vibe preflight
+
+# 2) generate/update postflight
+cat .vibe/artifacts/postflight.json
+
+# 3) validate artifact
+vibe postflight
+
+# 4) preview tracker updates first
+vibe postflight --apply --dry-run
+
+# 5) apply for real
+vibe postflight --apply
+```
+
+## Agent workflow (AGENTS.md)
+
+This repo supports LLM-driven development. The file `AGENTS.md` is the agent contract:
+
+- Issue-first (one topic = one issue)
+- Mandatory preflight -> work -> postflight
+- Append-only (never overwrite user notes)
+- Multi-pass reviews (Security/Quality/UX/Ops)
+
+LLMs (Codex, Claude, etc.) must read and follow `AGENTS.md` before making changes.
+
+## Canonical commands (recommended)
+
+Use these for deterministic execution:
+
+```bash
+pnpm build
+node dist/cli.cjs preflight
+node dist/cli.cjs postflight
+node dist/cli.cjs postflight --apply --dry-run
+node dist/cli.cjs postflight --apply
+```


### PR DESCRIPTION
## Summary
- add README.md for setup and usage from source
- document canonical reproducible commands using node dist/cli.cjs
- document convenience global vibe path via pnpm link --global
- include issue-first/postflight workflow and AGENTS.md contract notes

## Scope
- docs only

## Validation
- manual docs review