### PR TITLE
feat(cli): add vibe init for agent-first repo setup

### DIFF
--- a/.vibe/reviews/29/implementation.md
+++ b/.vibe/reviews/29/implementation.md
@@ -1,0 +1,14 @@
+# Implementation Pass
+
+- Added `vibe init` command in CLI with options:
+  - `--dry-run`
+  - `--skip-tracker`
+- Added core scaffold module (`src/core/init.ts`) to initialize agent-first repo baseline:
+  - `.vibe` directory structure
+  - `.vibe/contract.yml`
+  - `.vibe/ownership.yml`
+  - starter `.vibe/artifacts/postflight.json` (create-only)
+  - `AGENTS.md` managed snippet (append/upsert via markers)
+  - `.gitignore` entries for `.vibe/runtime` and `.vibe/artifacts`
+- Integrated tracker taxonomy setup by reusing tracker bootstrap logic from `init`.
+- Updated README quickstart/workflow to use `vibe init` instead of manual scaffolding.

--- a/.vibe/reviews/29/ops.md
+++ b/.vibe/reviews/29/ops.md
@@ -1,0 +1,7 @@
+# Ops/Release Pass
+
+- New CLI entrypoint: `vibe init`.
+- Release impact is additive; existing commands remain backward-compatible.
+- Recommended rollout path:
+  - validate `vibe init --dry-run` in a target repo
+  - then run `vibe init` and confirm tracker/bootstrap and generated files.

--- a/.vibe/reviews/29/quality.md
+++ b/.vibe/reviews/29/quality.md
@@ -1,0 +1,10 @@
+# Quality Pass
+
+- Added CLI tests for `vibe init`:
+  - empty repo bootstrap + tracker integration
+  - idempotent rerun preserving existing postflight artifact
+  - dry-run mode with no filesystem writes
+- Validation commands run:
+  - `pnpm test` (pass)
+  - `pnpm build` (pass)
+- Untested: real GitHub side effects from `vibe init` in a non-mocked external repo (covered by existing bootstrap command behavior).

--- a/.vibe/reviews/29/security.md
+++ b/.vibe/reviews/29/security.md
@@ -1,0 +1,6 @@
+# Security Pass
+
+- No new dependency or secret-handling surface introduced.
+- File writes are constrained to repo-local paths and idempotent create/upsert behavior.
+- Tracker bootstrap still relies on authenticated `gh` context; `--skip-tracker` allows local-only init when network/auth is unavailable.
+- Residual risk: AGENTS upsert appends managed snippet when markers are absent; behavior is intentional but should be visible in docs.

--- a/README.md
+++ b/README.md
@@ -68,54 +68,14 @@ vibe --help
 ```bash
 cd /path/to/another-repo
 
-# create a starter postflight artifact (required before postflight/apply)
-mkdir -p .vibe/artifacts
-cat > .vibe/artifacts/postflight.json <<'EOF'
-{
-  "version": 1,
-  "meta": {
-    "timestamp": "2026-01-01T00:00:00.000Z",
-    "actor": "agent",
-    "mode": "cli"
-  },
-  "work": {
-    "issue_id": "1",
-    "branch": "main",
-    "base_branch": "main"
-  },
-  "checks": {
-    "tests": {
-      "ran": false,
-      "result": "skipped"
-    }
-  },
-  "tracker_updates": [
-    {
-      "type": "comment_append",
-      "body": "Initial postflight draft."
-    }
-  ],
-  "next_actions": [
-    "Replace this line with the next concrete action."
-  ],
-  "risks": {
-    "summary": "Initial draft before real changes.",
-    "rollback_plan": "No tracker updates applied yet."
-  }
-}
-EOF
-
-# IMPORTANT: replace placeholder issue_id with your active GitHub issue number
-# before any --apply command.
-# Replace this field:
-#   "issue_id": "1"
-# with your real issue id, for example:
-#   "issue_id": "42"
+# one-time setup for agent-first workflow
+vibe init --dry-run
+vibe init
+# if gh is unavailable, scaffold local files only
+# vibe init --skip-tracker
 
 # now these commands are valid
 vibe preflight
-vibe tracker bootstrap --dry-run
-vibe tracker bootstrap
 vibe postflight
 vibe postflight --apply --dry-run
 ```
@@ -129,54 +89,14 @@ node /path/to/vibe-backlog/dist/cli.cjs preflight
 ## 4) Recommended workflow (Issue-first + Postflight)
 
 ```bash
+# 0) one-time setup in this repo
+vibe init --dry-run
+vibe init
+
 # 1) inspect repo + issue state
 vibe preflight
 
-# 1.1) one-time tracker taxonomy bootstrap (per repo)
-vibe tracker bootstrap --dry-run
-vibe tracker bootstrap
-
-# 2) create or update postflight artifact
-mkdir -p .vibe/artifacts
-if [ ! -f .vibe/artifacts/postflight.json ]; then
-  cat > .vibe/artifacts/postflight.json <<'EOF'
-{
-  "version": 1,
-  "meta": {
-    "timestamp": "2026-01-01T00:00:00.000Z",
-    "actor": "agent",
-    "mode": "cli"
-  },
-  "work": {
-    "issue_id": "1",
-    "branch": "main",
-    "base_branch": "main"
-  },
-  "checks": {
-    "tests": {
-      "ran": false,
-      "result": "skipped"
-    }
-  },
-  "tracker_updates": [
-    {
-      "type": "comment_append",
-      "body": "Initial postflight draft."
-    }
-  ],
-  "next_actions": [
-    "Replace this line with the next concrete action."
-  ],
-  "risks": {
-    "summary": "Initial draft before real changes.",
-    "rollback_plan": "No tracker updates applied yet."
-  }
-}
-EOF
-fi
-cat .vibe/artifacts/postflight.json
-
-# 2.1) set the real active issue id before apply
+# 2) set the real active issue id before apply
 # Edit .vibe/artifacts/postflight.json and replace:
 #   "issue_id": "1"
 # with your real issue number, for example:
@@ -212,6 +132,8 @@ Use these for deterministic execution:
 ```bash
 pnpm build
 node dist/cli.cjs preflight
+node dist/cli.cjs init --dry-run
+node dist/cli.cjs init
 node dist/cli.cjs tracker bootstrap --dry-run
 node dist/cli.cjs tracker bootstrap
 node dist/cli.cjs postflight

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@ export * from "./service";
 export * from "./postflight";
 export * from "./turn";
 export * from "./tracker";
+export * from "./init";

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1,0 +1,238 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type InitScaffoldResult = {
+  created: string[];
+  updated: string[];
+  unchanged: string[];
+};
+
+type InitScaffoldOptions = {
+  cwd?: string;
+  dryRun: boolean;
+};
+
+const VIBE_DIRECTORIES = [".vibe", ".vibe/runtime", ".vibe/artifacts", ".vibe/templates", ".vibe/reviews", ".vibe/pills"];
+const AGENT_SNIPPET_START = "<!-- vibe:agent-snippet:start -->";
+const AGENT_SNIPPET_END = "<!-- vibe:agent-snippet:end -->";
+const TRACKER_GITIGNORE_ENTRIES = [".vibe/runtime", ".vibe/artifacts"];
+
+const DEFAULT_CONTRACT_YAML = `version: 1
+project:
+  source_of_truth: "github"
+
+interaction_contract:
+  preflight:
+    required:
+      - git_status
+      - tracker_open_items_summary
+      - tests_last_result_or_run_plan
+  postflight:
+    required:
+      - tracker_update_status
+      - tracker_append_agent_log
+      - record_tests_result
+      - next_actions
+      - risks_and_rollbacks
+
+editing_rules:
+  agent:
+    append_only_default: true
+    may_edit_user_notes: false
+`;
+
+const DEFAULT_OWNERSHIP_YAML = `version: 1
+protected_sections:
+  markers:
+    user_notes:
+      start: "<!-- vibe:user-notes:start -->"
+      end: "<!-- vibe:user-notes:end -->"
+    agent_log:
+      start: "<!-- vibe:agent-log:start -->"
+      end: "<!-- vibe:agent-log:end -->"
+rules:
+  default:
+    agent_can: ["append_comment"]
+    agent_cannot: ["overwrite_issue_body", "edit_user_notes_section"]
+`;
+
+function buildDefaultPostflightJson(now: string): string {
+  const payload = {
+    version: 1,
+    meta: {
+      timestamp: now,
+      actor: "agent",
+      mode: "cli",
+    },
+    work: {
+      issue_id: "1",
+      branch: "main",
+      base_branch: "main",
+    },
+    checks: {
+      tests: {
+        ran: false,
+        result: "skipped",
+      },
+    },
+    tracker_updates: [
+      {
+        type: "comment_append",
+        body: "Initial postflight draft.",
+      },
+    ],
+    next_actions: ["Replace this line with the next concrete action."],
+    risks: {
+      summary: "Initial draft before real changes.",
+      rollback_plan: "No tracker updates applied yet.",
+    },
+  };
+
+  return `${JSON.stringify(payload, null, 2)}\n`;
+}
+
+function buildAgentSnippetBlock(): string {
+  const body = [
+    "## Vibe Agent Workflow (Managed)",
+    "- Run `node dist/cli.cjs preflight` before implementation.",
+    "- Use one issue per topic and keep tracker labels/milestones updated.",
+    "- Validate with `node dist/cli.cjs postflight` and apply updates with `node dist/cli.cjs postflight --apply`.",
+  ].join("\n");
+
+  return `${AGENT_SNIPPET_START}\n${body}\n${AGENT_SNIPPET_END}\n`;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pushChange(result: InitScaffoldResult, kind: keyof InitScaffoldResult, filePath: string): void {
+  result[kind].push(filePath);
+}
+
+async function ensureDirectory(dirPath: string, dryRun: boolean, result: InitScaffoldResult): Promise<void> {
+  if (await pathExists(dirPath)) {
+    pushChange(result, "unchanged", dirPath);
+    return;
+  }
+
+  if (!dryRun) {
+    await mkdir(dirPath, { recursive: true });
+  }
+  pushChange(result, "created", dirPath);
+}
+
+async function ensureFile(filePath: string, content: string, dryRun: boolean, result: InitScaffoldResult): Promise<void> {
+  if (await pathExists(filePath)) {
+    pushChange(result, "unchanged", filePath);
+    return;
+  }
+
+  if (!dryRun) {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, content, "utf8");
+  }
+  pushChange(result, "created", filePath);
+}
+
+async function upsertAgentSnippet(agentsPath: string, dryRun: boolean, result: InitScaffoldResult): Promise<void> {
+  const snippet = buildAgentSnippetBlock();
+  const agentsExists = await pathExists(agentsPath);
+
+  if (!agentsExists) {
+    const content = `# AGENTS\n\n${snippet}`;
+    if (!dryRun) {
+      await writeFile(agentsPath, content, "utf8");
+    }
+    pushChange(result, "created", agentsPath);
+    return;
+  }
+
+  const current = await readFile(agentsPath, "utf8");
+  const start = current.indexOf(AGENT_SNIPPET_START);
+  const end = current.indexOf(AGENT_SNIPPET_END);
+
+  let next = current;
+  if (start >= 0 && end > start) {
+    const endWithMarker = end + AGENT_SNIPPET_END.length;
+    next = `${current.slice(0, start)}${snippet}${current.slice(endWithMarker)}`;
+  } else if (!current.includes(AGENT_SNIPPET_START)) {
+    const separator = current.endsWith("\n") ? "\n" : "\n\n";
+    next = `${current}${separator}${snippet}`;
+  }
+
+  if (next === current) {
+    pushChange(result, "unchanged", agentsPath);
+    return;
+  }
+
+  if (!dryRun) {
+    await writeFile(agentsPath, next, "utf8");
+  }
+  pushChange(result, "updated", agentsPath);
+}
+
+async function upsertGitignoreEntries(gitignorePath: string, dryRun: boolean, result: InitScaffoldResult): Promise<void> {
+  const exists = await pathExists(gitignorePath);
+  if (!exists) {
+    const content = `${TRACKER_GITIGNORE_ENTRIES.join("\n")}\n`;
+    if (!dryRun) {
+      await writeFile(gitignorePath, content, "utf8");
+    }
+    pushChange(result, "created", gitignorePath);
+    return;
+  }
+
+  const current = await readFile(gitignorePath, "utf8");
+  const lines = new Set(
+    current
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean),
+  );
+  const missing = TRACKER_GITIGNORE_ENTRIES.filter((entry) => !lines.has(entry));
+
+  if (!missing.length) {
+    pushChange(result, "unchanged", gitignorePath);
+    return;
+  }
+
+  const prefix = current.endsWith("\n") ? "" : "\n";
+  const next = `${current}${prefix}${missing.join("\n")}\n`;
+  if (!dryRun) {
+    await writeFile(gitignorePath, next, "utf8");
+  }
+  pushChange(result, "updated", gitignorePath);
+}
+
+export async function scaffoldVibeInit(options: InitScaffoldOptions): Promise<InitScaffoldResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const dryRun = options.dryRun;
+  const result: InitScaffoldResult = {
+    created: [],
+    updated: [],
+    unchanged: [],
+  };
+
+  for (const relativeDir of VIBE_DIRECTORIES) {
+    await ensureDirectory(path.join(cwd, relativeDir), dryRun, result);
+  }
+
+  await ensureFile(path.join(cwd, ".vibe", "contract.yml"), DEFAULT_CONTRACT_YAML, dryRun, result);
+  await ensureFile(path.join(cwd, ".vibe", "ownership.yml"), DEFAULT_OWNERSHIP_YAML, dryRun, result);
+  await ensureFile(
+    path.join(cwd, ".vibe", "artifacts", "postflight.json"),
+    buildDefaultPostflightJson(new Date().toISOString()),
+    dryRun,
+    result,
+  );
+  await upsertAgentSnippet(path.join(cwd, "AGENTS.md"), dryRun, result);
+  await upsertGitignoreEntries(path.join(cwd, ".gitignore"), dryRun, result);
+
+  return result;
+}

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -1,0 +1,114 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createProgram } from "../src/cli-program";
+import { getTrackerBootstrapMarkerPath } from "../src/core/tracker";
+
+describe.sequential("cli init", () => {
+  const originalCwd = process.cwd();
+  let tempDir = "";
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "vibe-cli-init-test-"));
+    process.chdir(tempDir);
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("initializes empty repo scaffold and runs tracker bootstrap", async () => {
+    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
+      if (args[0] === "repo" && args[1] === "view") {
+        return { stdout: "acme/demo\n" };
+      }
+      if (args[0] === "api" && args[1] === "repos/acme/demo/milestones?state=all&per_page=100&page=1") {
+        return { stdout: "[]" };
+      }
+      if (args[0] === "api" && args[1] === "repos/acme/demo/labels?per_page=100&page=1") {
+        return { stdout: "[]" };
+      }
+      return { stdout: "" };
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init"]);
+
+    expect(existsSync(path.join(tempDir, ".vibe", "contract.yml"))).toBe(true);
+    expect(existsSync(path.join(tempDir, ".vibe", "ownership.yml"))).toBe(true);
+    expect(existsSync(path.join(tempDir, ".vibe", "artifacts", "postflight.json"))).toBe(true);
+    expect(existsSync(path.join(tempDir, "AGENTS.md"))).toBe(true);
+    expect(readFileSync(path.join(tempDir, "AGENTS.md"), "utf8")).toContain("<!-- vibe:agent-snippet:start -->");
+    expect(readFileSync(path.join(tempDir, ".gitignore"), "utf8")).toContain(".vibe/runtime");
+    expect(existsSync(getTrackerBootstrapMarkerPath())).toBe(true);
+
+    const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
+    expect(
+      commands.some(
+        ([cmd, args]) =>
+          cmd === "gh" &&
+          args[0] === "api" &&
+          args[1] === "--method" &&
+          args[2] === "POST" &&
+          args[3] === "repos/acme/demo/milestones",
+      ),
+    ).toBe(true);
+    expect(
+      commands.some(([cmd, args]) => cmd === "gh" && args[0] === "label" && args[1] === "create" && args[2] === "module:cli"),
+    ).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("is idempotent and does not overwrite existing postflight artifact", async () => {
+    writeFileSync(path.join(tempDir, "AGENTS.md"), "# Custom\n", "utf8");
+    writeFileSync(path.join(tempDir, ".gitignore"), "node_modules\n", "utf8");
+
+    const customPostflight = '{"version":1,"custom":true}\n';
+    const postflightPath = path.join(tempDir, ".vibe", "artifacts", "postflight.json");
+    // First run creates scaffold.
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+    writeFileSync(postflightPath, customPostflight, "utf8");
+
+    // Second run should preserve existing files and keep one managed snippet block.
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    expect(readFileSync(postflightPath, "utf8")).toBe(customPostflight);
+    const agents = readFileSync(path.join(tempDir, "AGENTS.md"), "utf8");
+    expect((agents.match(/<!-- vibe:agent-snippet:start -->/g) ?? []).length).toBe(1);
+    expect(agents).toContain("# Custom");
+    expect(readFileSync(path.join(tempDir, ".gitignore"), "utf8")).toContain(".vibe/artifacts");
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  it("supports dry-run without touching filesystem", async () => {
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--dry-run", "--skip-tracker"]);
+
+    expect(existsSync(path.join(tempDir, ".vibe"))).toBe(false);
+    expect(existsSync(path.join(tempDir, "AGENTS.md"))).toBe(false);
+    expect(existsSync(path.join(tempDir, ".gitignore"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add new `vibe init` command for agent-first repo setup
- scaffold `.vibe` baseline files/directories idempotently
- upsert managed agent snippet in `AGENTS.md` without overwriting user content
- ensure `.gitignore` contains `.vibe/runtime` and `.vibe/artifacts`
- integrate tracker taxonomy setup from init flow (with `--skip-tracker` and `--dry-run` support)
- update README quickstart/workflow to use `vibe init`

## Architecture decisions
- Implemented a dedicated core module (`src/core/init.ts`) for scaffold logic, separate from CLI wiring.
- Reused tracker bootstrap logic through a shared helper in CLI instead of invoking nested CLI commands.
- Used marker-based snippet upsert in `AGENTS.md` to preserve non-managed user content.

## Why these decisions
- Separation keeps `cli-program.ts` focused on command orchestration and improves testability.
- Shared helper avoids shell recursion and keeps `--dry-run` behavior consistent across commands.
- Marker-based updates provide deterministic idempotency while staying non-destructive.

## Alternatives considered
- Calling `vibe tracker bootstrap` as a subprocess from `init`: rejected for complexity and harder testability.
- Overwriting full `AGENTS.md`: rejected to preserve user-owned content.

## Testing
- `pnpm test`
- `pnpm build`

Fixes #29
