### PR TITLE
feat(turn): auto-create review templates per issue on turn start

### DIFF
--- a/.vibe/reviews/12/implementation.md
+++ b/.vibe/reviews/12/implementation.md
@@ -1,0 +1,9 @@
+# Implementation Pass
+
+- Scope: auto-create review templates under `.vibe/reviews/<issue_id>/` when running `turn start`.
+- Changes:
+  - Added `src/core/reviews.ts` with deterministic, non-overwriting template creation.
+  - Wired template creation into `turn start` in `src/cli-program.ts`.
+  - Exported new review helpers from `src/core/index.ts`.
+  - Added tests for template creation/idempotency and CLI integration.
+- Result: templates are now created automatically per issue while preserving existing notes.

--- a/.vibe/reviews/12/ops.md
+++ b/.vibe/reviews/12/ops.md
@@ -1,0 +1,8 @@
+# Ops Pass
+
+- Determinism: behavior uses repo-local paths and deterministic file set/order.
+- Repro validation:
+  - `pnpm test`
+  - `pnpm build`
+- Release risk: low; change is additive and preserves existing files.
+- Rollback: revert commit for this issue branch if needed.

--- a/.vibe/reviews/12/quality.md
+++ b/.vibe/reviews/12/quality.md
@@ -1,0 +1,10 @@
+# Quality Pass
+
+- Added tests:
+  - `tests/reviews.test.ts` (creation + idempotency/no-overwrite).
+  - `tests/cli-turn.test.ts` (`turn start` creates turn context + review templates).
+- Commands run:
+  - `pnpm test`
+  - `pnpm build`
+- Result: all tests passing.
+- Untested: real `gh` network execution path for `turn start` title lookup (mocked in tests).

--- a/.vibe/reviews/12/security.md
+++ b/.vibe/reviews/12/security.md
@@ -1,0 +1,8 @@
+# Security Pass
+
+- Threat scan: low risk change, filesystem writes constrained to local workspace under `.vibe/reviews/<issue_id>/`.
+- Checks:
+  - Input guard: `issueId` must be positive safe integer.
+  - Overwrite safety: existing files are never rewritten.
+  - Error handling: unexpected FS errors surface and fail command (no silent corruption).
+- Residual risk: none beyond standard local filesystem permissions/errors.

--- a/.vibe/reviews/12/ux.md
+++ b/.vibe/reviews/12/ux.md
@@ -1,0 +1,4 @@
+# UX Pass
+
+- Not applicable: no UI surface changed in this issue.
+- CLI output update: `turn start` now prints template creation status for operator visibility.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ vibe postflight --apply
 
 `preflight` now prints a hint when `.vibe` exists but tracker bootstrap marker is missing.
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
+`turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 
 ## Agent workflow (AGENTS.md)
 

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -15,6 +15,7 @@ import {
   writeTrackerBootstrapMarker,
 } from "./core/tracker";
 import { buildTurnBranch, clearTurnContext, readTurnContext, validateTurnContext, writeTurnContext } from "./core/turn";
+import { ensureIssueReviewTemplates } from "./core/reviews";
 
 type ExecaFn = typeof execa;
 const GUARD_NO_ACTIVE_TURN_EXIT_CODE = 2;
@@ -460,6 +461,12 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         };
 
         await writeTurnContext(turnContext);
+        const reviewTemplates = await ensureIssueReviewTemplates(issueId);
+        if (reviewTemplates.created.length) {
+          console.log(`review templates: created ${reviewTemplates.created.length} file(s) at ${reviewTemplates.directory}`);
+        } else {
+          console.log(`review templates: already present at ${reviewTemplates.directory}`);
+        }
         console.log(JSON.stringify(turnContext, null, 2));
       } catch (error) {
         console.error("turn start: ERROR");

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./postflight";
 export * from "./turn";
 export * from "./tracker";
 export * from "./init";
+export * from "./reviews";

--- a/src/core/reviews.ts
+++ b/src/core/reviews.ts
@@ -1,0 +1,159 @@
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export type ReviewTemplateOptions = {
+  workspaceRoot?: string;
+};
+
+export type ReviewTemplateResult = {
+  directory: string;
+  created: string[];
+  unchanged: string[];
+};
+
+type ReviewTemplate = {
+  fileName: string;
+  content: string;
+};
+
+const REVIEW_TEMPLATES: readonly ReviewTemplate[] = [
+  {
+    fileName: "implementation.md",
+    content: `# Implementation Pass
+
+## Scope
+- Issue:
+- Goal:
+
+## Checklist
+- [ ] Diff kept focused to issue scope
+- [ ] Behavior changes documented
+- [ ] Follow-up work listed (if any)
+
+## Notes
+- 
+`,
+  },
+  {
+    fileName: "security.md",
+    content: `# Security Pass
+
+## Threat Scan
+- Risks considered:
+- Mitigations applied:
+
+## Checklist
+- [ ] Input validation paths reviewed
+- [ ] Authorization/data exposure reviewed
+- [ ] Error handling avoids sensitive leakage
+
+## Notes
+- 
+`,
+  },
+  {
+    fileName: "quality.md",
+    content: `# Quality Pass
+
+## What I Tested
+- Commands:
+- Scenarios:
+
+## Checklist
+- [ ] Happy path validated
+- [ ] Failure/edge path validated
+- [ ] Remaining gaps captured
+
+## Notes
+- 
+`,
+  },
+  {
+    fileName: "ux.md",
+    content: `# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+`,
+  },
+  {
+    fileName: "ops.md",
+    content: `# Ops Pass
+
+## Release Readiness
+- Commands run:
+- Operational risks:
+
+## Checklist
+- [ ] Build/test reproducibility validated
+- [ ] Rollback strategy noted
+- [ ] CI/deploy impact reviewed
+
+## Notes
+- 
+`,
+  },
+];
+
+export const REVIEW_TEMPLATE_FILE_NAMES = REVIEW_TEMPLATES.map((template) => template.fileName);
+
+function resolveWorkspaceRoot(options: ReviewTemplateOptions): string {
+  return options.workspaceRoot ?? process.cwd();
+}
+
+function validateIssueId(issueId: number): void {
+  if (!Number.isSafeInteger(issueId) || issueId <= 0) {
+    throw new Error("issueId must be a positive integer");
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await stat(filePath);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+export function getIssueReviewDirectory(issueId: number, options: ReviewTemplateOptions = {}): string {
+  validateIssueId(issueId);
+  return path.resolve(resolveWorkspaceRoot(options), ".vibe", "reviews", String(issueId));
+}
+
+export async function ensureIssueReviewTemplates(
+  issueId: number,
+  options: ReviewTemplateOptions = {},
+): Promise<ReviewTemplateResult> {
+  const directory = getIssueReviewDirectory(issueId, options);
+  await mkdir(directory, { recursive: true });
+
+  const created: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const template of REVIEW_TEMPLATES) {
+    const filePath = path.join(directory, template.fileName);
+    if (await pathExists(filePath)) {
+      unchanged.push(filePath);
+      continue;
+    }
+
+    await writeFile(filePath, template.content, "utf8");
+    created.push(filePath);
+  }
+
+  return { directory, created, unchanged };
+}

--- a/tests/cli-turn.test.ts
+++ b/tests/cli-turn.test.ts
@@ -1,0 +1,73 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createProgram } from "../src/cli-program";
+import { REVIEW_TEMPLATE_FILE_NAMES } from "../src/core/reviews";
+import { getTurnContextPath } from "../src/core/turn";
+
+describe.sequential("cli turn start", () => {
+  const originalCwd = process.cwd();
+  let tempDir = "";
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "vibe-cli-turn-test-"));
+    process.chdir(tempDir);
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates turn context and review templates on turn start", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async (cmd: string, args: string[]) => {
+      if (cmd === "gh" && args[0] === "issue" && args[1] === "view" && args[2] === "12") {
+        return { stdout: "Auto-create review templates\n" };
+      }
+      if (cmd === "git" && args[0] === "show-ref") {
+        return { stdout: "", exitCode: 1 };
+      }
+      if (cmd === "git" && args[0] === "checkout" && args[1] === "-b") {
+        return { stdout: "" };
+      }
+
+      throw new Error(`unexpected command: ${cmd} ${args.join(" ")}`);
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "turn", "start", "--issue", "12"]);
+
+    const turnPath = getTurnContextPath();
+    expect(existsSync(turnPath)).toBe(true);
+    expect(readFileSync(turnPath, "utf8")).toContain('"issue_id": 12');
+
+    const reviewDir = path.join(tempDir, ".vibe", "reviews", "12");
+    for (const fileName of REVIEW_TEMPLATE_FILE_NAMES) {
+      expect(existsSync(path.join(reviewDir, fileName))).toBe(true);
+    }
+
+    const checkoutCreate = execaMock.mock.calls.find(
+      ([cmd, args]) => cmd === "git" && Array.isArray(args) && args[0] === "checkout" && args[1] === "-b",
+    );
+    expect(checkoutCreate).toBeDefined();
+    expect(String(checkoutCreate?.[1]?.[2] ?? "")).toMatch(/^issue-12-/);
+    expect(logs.some((line) => line.includes("review templates: created 5 file(s)"))).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/tests/reviews.test.ts
+++ b/tests/reviews.test.ts
@@ -1,0 +1,57 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ensureIssueReviewTemplates, getIssueReviewDirectory, REVIEW_TEMPLATE_FILE_NAMES } from "../src/core/reviews";
+
+describe.sequential("review templates", () => {
+  const originalCwd = process.cwd();
+  let tempDir = "";
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "vibe-reviews-test-"));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates per-issue review templates deterministically", async () => {
+    const result = await ensureIssueReviewTemplates(12);
+
+    expect(result.directory).toBe(getIssueReviewDirectory(12));
+    expect(result.created).toHaveLength(REVIEW_TEMPLATE_FILE_NAMES.length);
+    expect(result.unchanged).toEqual([]);
+
+    for (const fileName of REVIEW_TEMPLATE_FILE_NAMES) {
+      const filePath = path.join(result.directory, fileName);
+      expect(existsSync(filePath)).toBe(true);
+    }
+
+    expect(readFileSync(path.join(result.directory, "implementation.md"), "utf8")).toContain("# Implementation Pass");
+    expect(readFileSync(path.join(result.directory, "security.md"), "utf8")).toContain("# Security Pass");
+    expect(readFileSync(path.join(result.directory, "quality.md"), "utf8")).toContain("# Quality Pass");
+    expect(readFileSync(path.join(result.directory, "ux.md"), "utf8")).toContain("# UX Pass");
+    expect(readFileSync(path.join(result.directory, "ops.md"), "utf8")).toContain("# Ops Pass");
+  });
+
+  it("is idempotent and never overwrites existing review files", async () => {
+    await ensureIssueReviewTemplates(12);
+
+    const securityPath = path.join(getIssueReviewDirectory(12), "security.md");
+    const customContent = "# Custom Security Notes\n\nKeep this content.\n";
+    writeFileSync(securityPath, customContent, "utf8");
+
+    const result = await ensureIssueReviewTemplates(12);
+
+    expect(result.created).toEqual([]);
+    expect(result.unchanged).toHaveLength(REVIEW_TEMPLATE_FILE_NAMES.length);
+    expect(readFileSync(securityPath, "utf8")).toBe(customContent);
+  });
+});


### PR DESCRIPTION
## Summary
- add core helper to ensure .vibe/reviews/<issue_id>/ templates exist for implementation/security/quality/ux/ops
- run template scaffolding automatically during vibe turn start without overwriting existing files
- add tests for deterministic creation + idempotency and CLI turn-start integration
- document turn-start template behavior in README

## Validation
- pnpm test
- pnpm build

Fixes #12