### PR TITLE
#27 feat: add repo-agnostic tracker reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ vibe postflight --apply
 `turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 `review` runs the 5 role passes via external agent command, retries up to `--max-attempts`, publishes one final PR report, and can auto-create follow-up issues when unresolved findings remain.
 `pr open` creates/reuses an open PR for the issue and injects deterministic architecture/rationale sections plus `Fixes #<issue>`.
+`tracker reconcile` fills missing `module:*` labels and milestone metadata using repo-specific taxonomy/history, with interactive or flag-based fallbacks.
 
 ## Agent workflow (AGENTS.md)
 
@@ -145,10 +146,30 @@ node dist/cli.cjs init --dry-run
 node dist/cli.cjs init
 node dist/cli.cjs tracker bootstrap --dry-run
 node dist/cli.cjs tracker bootstrap
+node dist/cli.cjs tracker reconcile --dry-run
+node dist/cli.cjs tracker reconcile --fallback-module module:core --fallback-milestone "<milestone>"
 node dist/cli.cjs postflight
 node dist/cli.cjs postflight --apply --dry-run
 node dist/cli.cjs postflight --apply
 ```
+
+## `vibe tracker reconcile` command reference
+
+```bash
+vibe tracker reconcile [options]
+```
+
+Options:
+
+- `--dry-run`: build and print reconcile plan only.
+- `--fallback-module <name>`: module label/name to use when module inference is uncertain.
+- `--fallback-milestone <title>`: milestone title to use when milestone inference is uncertain.
+
+Behavior:
+
+- Default mode applies updates (`gh issue edit`) to open issues with missing `module:*` or milestone.
+- In non-interactive sessions, unresolved decisions degrade to plan-only and exit `0`.
+- Reconcile never removes/replaces existing module labels or milestone; it only fills missing metadata.
 
 ## `vibe review` command reference
 

--- a/src/core/tracker.ts
+++ b/src/core/tracker.ts
@@ -1,5 +1,6 @@
 import { mkdir, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { execa } from "execa";
 
 export type TrackerMilestoneDefinition = {
   title: string;
@@ -11,6 +12,84 @@ export type TrackerLabelDefinition = {
   color: string;
   description: string;
 };
+
+type ExecaFn = typeof execa;
+type JsonRecord = Record<string, unknown>;
+
+const GH_API_PAGE_SIZE = 100;
+const LABEL_SIGNAL_WEIGHT = 5;
+const TITLE_SIGNAL_WEIGHT = 3;
+const BODY_SIGNAL_WEIGHT = 1;
+const MODULE_RATIO_THRESHOLD = 1.5;
+const MILESTONE_CONFIDENCE_THRESHOLD = 0.8;
+
+const STOP_WORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "this",
+  "that",
+  "from",
+  "into",
+  "onto",
+  "over",
+  "under",
+  "between",
+  "about",
+  "after",
+  "before",
+  "issue",
+  "open",
+  "closed",
+  "create",
+  "update",
+  "fix",
+  "feat",
+  "chore",
+  "task",
+  "todo",
+  "when",
+  "then",
+  "there",
+  "their",
+  "have",
+  "has",
+  "had",
+  "will",
+  "would",
+  "should",
+  "could",
+  "can",
+  "cannot",
+  "cant",
+  "was",
+  "were",
+  "are",
+  "is",
+  "you",
+  "your",
+  "our",
+  "its",
+  "they",
+  "them",
+  "what",
+  "why",
+  "how",
+  "out",
+  "all",
+  "any",
+  "not",
+  "but",
+  "only",
+  "just",
+  "very",
+  "more",
+  "less",
+  "each",
+  "per",
+  "new",
+]);
 
 export const TRACKER_BOOTSTRAP_MILESTONES: readonly TrackerMilestoneDefinition[] = [
   {
@@ -59,12 +138,565 @@ export const TRACKER_BOOTSTRAP_LABELS: readonly TrackerLabelDefinition[] = [
 
 const TRACKER_BOOTSTRAP_MARKER = path.join(".vibe", "runtime", "tracker-bootstrap.json");
 
+type TrackerIssueSnapshot = {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+  milestone: string | null;
+  state: string;
+};
+
+type ModuleProfile = {
+  label: string;
+  tokenWeights: Map<string, number>;
+  slugTokens: string[];
+};
+
+export type TrackerReconcilePromptRequest = {
+  kind: "module" | "milestone";
+  issueNumber: number;
+  issueTitle: string;
+  suggestions: string[];
+};
+
+export type TrackerReconcilePromptFn = (request: TrackerReconcilePromptRequest) => Promise<string | null>;
+
+export type TrackerReconcileOptions = {
+  dryRun: boolean;
+  fallbackModule?: string | null;
+  fallbackMilestone?: string | null;
+};
+
+export type TrackerReconcileIssueUpdate = {
+  issueNumber: number;
+  issueTitle: string;
+  addLabels: string[];
+  setMilestone: string | null;
+  moduleSource: "existing" | "explicit" | "scored" | "fallback" | "prompt" | "none";
+  moduleConfidence: number | null;
+  milestoneSource: "existing" | "inferred" | "fallback" | "prompt" | "none";
+  milestoneConfidence: number | null;
+  notes: string[];
+};
+
+export type TrackerReconcileResult = {
+  repo: string;
+  dryRun: boolean;
+  applied: boolean;
+  degradedToPlanOnly: boolean;
+  planOnlyReason: string | null;
+  issueUpdates: TrackerReconcileIssueUpdate[];
+  unresolvedIssueIds: number[];
+  createdLabels: string[];
+  commands: string[][];
+};
+
+export type TrackerReconcileDependencies = {
+  execaFn?: ExecaFn;
+  promptFn?: TrackerReconcilePromptFn;
+  isInteractive?: boolean;
+};
+
 export function getTrackerBootstrapMarkerPath(cwd: string = process.cwd()): string {
   return path.resolve(cwd, TRACKER_BOOTSTRAP_MARKER);
 }
 
 function normalizeTrackerLabelName(value: string): string {
   return value.trim().toLowerCase();
+}
+
+function normalizeMilestoneTitle(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parseJsonArray(stdout: string, context: string): JsonRecord[] {
+  const parsed = JSON.parse(stdout) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`${context}: expected array response`);
+  }
+  return parsed.filter((value): value is JsonRecord => typeof value === "object" && value !== null);
+}
+
+function parseLabelNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => {
+      if (typeof entry === "object" && entry !== null) {
+        const name = (entry as Record<string, unknown>).name;
+        if (typeof name === "string") {
+          return name.trim();
+        }
+      }
+      return "";
+    })
+    .filter(Boolean);
+}
+
+function parseIssueSnapshotsFromApiRows(rows: JsonRecord[]): TrackerIssueSnapshot[] {
+  const snapshots: TrackerIssueSnapshot[] = [];
+
+  for (const row of rows) {
+    if (typeof row.pull_request === "object" && row.pull_request !== null) {
+      continue;
+    }
+
+    const number = row.number;
+    const title = row.title;
+    const state = row.state;
+
+    if (typeof number !== "number" || !Number.isInteger(number) || number <= 0) continue;
+    if (typeof title !== "string" || !title.trim()) continue;
+    if (typeof state !== "string" || !state.trim()) continue;
+
+    const milestoneRaw = row.milestone;
+    const milestone =
+      typeof milestoneRaw === "object" &&
+      milestoneRaw !== null &&
+      typeof (milestoneRaw as Record<string, unknown>).title === "string"
+        ? String((milestoneRaw as Record<string, unknown>).title).trim() || null
+        : null;
+
+    const body = typeof row.body === "string" ? row.body : "";
+
+    snapshots.push({
+      number,
+      title: title.trim(),
+      body,
+      labels: parseLabelNames(row.labels),
+      milestone,
+      state: state.trim().toLowerCase(),
+    });
+  }
+
+  return snapshots;
+}
+
+function parseMilestoneTitles(rows: JsonRecord[]): string[] {
+  return rows
+    .map((row) => row.title)
+    .filter((value): value is string => typeof value === "string")
+    .map((title) => title.trim())
+    .filter(Boolean);
+}
+
+function parseRepositoryLabelNames(rows: JsonRecord[]): string[] {
+  return rows
+    .map((row) => row.name)
+    .filter((value): value is string => typeof value === "string")
+    .map((name) => name.trim())
+    .filter(Boolean);
+}
+
+function upsertWeightedToken(map: Map<string, number>, token: string, weight: number): void {
+  if (!token) return;
+  map.set(token, (map.get(token) ?? 0) + weight);
+}
+
+function normalizeModuleLabel(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const withoutPrefix = normalizeTrackerLabelName(trimmed).startsWith("module:")
+    ? trimmed.trim().slice(trimmed.toLowerCase().indexOf(":") + 1)
+    : trimmed;
+
+  const slug = withoutPrefix
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!slug) return null;
+  return `module:${slug}`;
+}
+
+function extractModuleSlugTokens(moduleLabel: string): string[] {
+  const slug = moduleLabel.trim().toLowerCase().replace(/^module:/, "");
+  if (!slug) return [];
+  return slug
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2);
+}
+
+function extractModuleLabelMap(labelNames: Iterable<string>): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const label of labelNames) {
+    const normalized = normalizeTrackerLabelName(label);
+    if (!normalized.startsWith("module:")) continue;
+    if (!map.has(normalized)) {
+      map.set(normalized, label.trim());
+    }
+  }
+  return map;
+}
+
+export function sanitizeTrackerText(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/https?:\/\/\S+/g, " ")
+    .replace(/[\[\]{}()<>*_~#|]/g, " ")
+    .replace(/["'.,:;!?\\/+\-=]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenizeText(value: string): string[] {
+  const cleaned = sanitizeTrackerText(value);
+  if (!cleaned) return [];
+
+  return cleaned
+    .split(/[^a-z0-9]+/)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2)
+    .filter((token) => !STOP_WORDS.has(token));
+}
+
+function tokenizeLabels(labels: string[]): string[] {
+  const tokens: string[] = [];
+
+  for (const label of labels) {
+    const normalized = normalizeTrackerLabelName(label);
+    if (normalized.startsWith("status:")) continue;
+    tokens.push(...tokenizeText(label));
+  }
+
+  return tokens;
+}
+
+function buildIssueTokenWeights(issue: TrackerIssueSnapshot): Map<string, number> {
+  const tokens = new Map<string, number>();
+
+  for (const token of tokenizeLabels(issue.labels)) {
+    upsertWeightedToken(tokens, token, LABEL_SIGNAL_WEIGHT);
+  }
+
+  for (const token of tokenizeText(issue.title)) {
+    upsertWeightedToken(tokens, token, TITLE_SIGNAL_WEIGHT);
+  }
+
+  for (const token of tokenizeText(issue.body)) {
+    upsertWeightedToken(tokens, token, BODY_SIGNAL_WEIGHT);
+  }
+
+  return tokens;
+}
+
+function buildIssueTokenSet(issue: TrackerIssueSnapshot): Set<string> {
+  const set = new Set<string>();
+  for (const token of tokenizeLabels(issue.labels)) set.add(token);
+  for (const token of tokenizeText(issue.title)) set.add(token);
+  for (const token of tokenizeText(issue.body)) set.add(token);
+  return set;
+}
+
+function issueModuleLabels(issue: TrackerIssueSnapshot): string[] {
+  return issue.labels
+    .map((label) => normalizeTrackerLabelName(label))
+    .filter((label) => label.startsWith("module:"));
+}
+
+function buildModuleProfiles(moduleLabelMap: Map<string, string>, issues: TrackerIssueSnapshot[]): Map<string, ModuleProfile> {
+  const profiles = new Map<string, ModuleProfile>();
+
+  for (const [moduleLower, moduleLabel] of moduleLabelMap.entries()) {
+    const tokenWeights = new Map<string, number>();
+    const slugTokens = extractModuleSlugTokens(moduleLower);
+    for (const token of slugTokens) {
+      upsertWeightedToken(tokenWeights, token, LABEL_SIGNAL_WEIGHT + TITLE_SIGNAL_WEIGHT);
+    }
+    profiles.set(moduleLower, {
+      label: moduleLabel,
+      tokenWeights,
+      slugTokens,
+    });
+  }
+
+  for (const issue of issues) {
+    const modules = issueModuleLabels(issue).filter((label) => profiles.has(label));
+    if (!modules.length) continue;
+
+    const labelTokens = tokenizeLabels(issue.labels);
+    const titleTokens = tokenizeText(issue.title);
+    const bodyTokens = tokenizeText(issue.body);
+
+    for (const moduleLower of modules) {
+      const profile = profiles.get(moduleLower);
+      if (!profile) continue;
+
+      for (const token of labelTokens) {
+        upsertWeightedToken(profile.tokenWeights, token, LABEL_SIGNAL_WEIGHT);
+      }
+      for (const token of titleTokens) {
+        upsertWeightedToken(profile.tokenWeights, token, TITLE_SIGNAL_WEIGHT);
+      }
+      for (const token of bodyTokens) {
+        upsertWeightedToken(profile.tokenWeights, token, BODY_SIGNAL_WEIGHT);
+      }
+    }
+  }
+
+  return profiles;
+}
+
+function explicitModuleMatches(issue: TrackerIssueSnapshot, profiles: Map<string, ModuleProfile>): string[] {
+  const tokenSet = buildIssueTokenSet(issue);
+  const matched: string[] = [];
+
+  for (const [moduleLower, profile] of profiles.entries()) {
+    if (!profile.slugTokens.length) continue;
+
+    const slugTokenMatches = profile.slugTokens.every((token) => tokenSet.has(token));
+    if (slugTokenMatches) {
+      matched.push(moduleLower);
+    }
+  }
+
+  matched.sort((a, b) => a.localeCompare(b));
+  return matched;
+}
+
+function scoreModules(issue: TrackerIssueSnapshot, profiles: Map<string, ModuleProfile>): Array<{ module: string; score: number }> {
+  const issueWeights = buildIssueTokenWeights(issue);
+  const scored: Array<{ module: string; score: number }> = [];
+
+  for (const [moduleLower, profile] of profiles.entries()) {
+    let score = 0;
+    for (const [token, tokenWeight] of issueWeights.entries()) {
+      const modelWeight = profile.tokenWeights.get(token);
+      if (!modelWeight) continue;
+      score += tokenWeight * modelWeight;
+    }
+
+    if (score > 0) {
+      scored.push({ module: moduleLower, score });
+    }
+  }
+
+  scored.sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    return left.module.localeCompare(right.module);
+  });
+
+  return scored;
+}
+
+function inferModules(issue: TrackerIssueSnapshot, profiles: Map<string, ModuleProfile>): {
+  modules: string[];
+  source: "explicit" | "scored" | "none";
+  confidence: number | null;
+  suggestions: string[];
+} {
+  const explicit = explicitModuleMatches(issue, profiles);
+  if (explicit.length > 0) {
+    return {
+      modules: explicit,
+      source: "explicit",
+      confidence: 1,
+      suggestions: explicit,
+    };
+  }
+
+  const scored = scoreModules(issue, profiles);
+  const suggestions = scored.slice(0, 3).map((entry) => entry.module);
+
+  if (!scored.length) {
+    return {
+      modules: [],
+      source: "none",
+      confidence: null,
+      suggestions,
+    };
+  }
+
+  const top = scored[0];
+  const second = scored[1] ?? null;
+
+  if (!second || second.score <= 0) {
+    return {
+      modules: [top.module],
+      source: "scored",
+      confidence: 999,
+      suggestions,
+    };
+  }
+
+  const ratio = top.score / second.score;
+  if (ratio >= MODULE_RATIO_THRESHOLD) {
+    return {
+      modules: [top.module],
+      source: "scored",
+      confidence: ratio,
+      suggestions,
+    };
+  }
+
+  return {
+    modules: [],
+    source: "none",
+    confidence: ratio,
+    suggestions,
+  };
+}
+
+function buildMilestoneCountsByModule(
+  issues: TrackerIssueSnapshot[],
+  moduleLabelMap: Map<string, string>,
+): Map<string, Map<string, number>> {
+  const counts = new Map<string, Map<string, number>>();
+
+  for (const moduleLower of moduleLabelMap.keys()) {
+    counts.set(moduleLower, new Map<string, number>());
+  }
+
+  for (const issue of issues) {
+    if (!issue.milestone) continue;
+
+    const moduleLabels = issueModuleLabels(issue).filter((label) => counts.has(label));
+    if (!moduleLabels.length) continue;
+
+    for (const moduleLower of moduleLabels) {
+      const moduleCounts = counts.get(moduleLower);
+      if (!moduleCounts) continue;
+      moduleCounts.set(issue.milestone, (moduleCounts.get(issue.milestone) ?? 0) + 1);
+    }
+  }
+
+  return counts;
+}
+
+function inferMilestone(
+  modules: string[],
+  milestoneCountsByModule: Map<string, Map<string, number>>,
+): { milestone: string | null; confidence: number | null; suggestions: string[] } {
+  const aggregate = new Map<string, number>();
+
+  for (const moduleLower of modules) {
+    const moduleCounts = milestoneCountsByModule.get(moduleLower);
+    if (!moduleCounts) continue;
+
+    for (const [milestone, count] of moduleCounts.entries()) {
+      aggregate.set(milestone, (aggregate.get(milestone) ?? 0) + count);
+    }
+  }
+
+  const ordered = Array.from(aggregate.entries()).sort((left, right) => {
+    if (right[1] !== left[1]) return right[1] - left[1];
+    return left[0].localeCompare(right[0]);
+  });
+
+  const suggestions = ordered.slice(0, 3).map(([milestone]) => milestone);
+  if (!ordered.length) {
+    return {
+      milestone: null,
+      confidence: null,
+      suggestions,
+    };
+  }
+
+  const [topMilestone, topCount] = ordered[0];
+  const secondCount = ordered[1]?.[1] ?? 0;
+  const totalCount = ordered.reduce((acc, entry) => acc + entry[1], 0);
+
+  if (topCount === secondCount) {
+    return {
+      milestone: null,
+      confidence: totalCount ? topCount / totalCount : null,
+      suggestions,
+    };
+  }
+
+  const confidence = totalCount ? topCount / totalCount : 0;
+  if (confidence >= MILESTONE_CONFIDENCE_THRESHOLD) {
+    return {
+      milestone: topMilestone,
+      confidence,
+      suggestions,
+    };
+  }
+
+  return {
+    milestone: null,
+    confidence,
+    suggestions,
+  };
+}
+
+function colorFromSeed(seed: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  const color = (hash >>> 0) & 0xffffff;
+  return color.toString(16).toUpperCase().padStart(6, "0");
+}
+
+function buildGeneratedModuleLabelDefinition(name: string): TrackerLabelDefinition {
+  return {
+    name,
+    color: colorFromSeed(name),
+    description: "Generated module label by vibe tracker reconcile",
+  };
+}
+
+async function resolveRepoNameWithOwner(execaFn: ExecaFn): Promise<string> {
+  const response = await execaFn("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], {
+    stdio: "pipe",
+  });
+  const slug = response.stdout.trim();
+  if (!slug || !slug.includes("/")) {
+    throw new Error("tracker reconcile: unable to resolve repository owner/name from gh");
+  }
+  return slug;
+}
+
+async function listPaginatedGhApiRecords(execaFn: ExecaFn, endpoint: string, context: string): Promise<JsonRecord[]> {
+  const all: JsonRecord[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const separator = endpoint.includes("?") ? "&" : "?";
+    const paginatedEndpoint = `${endpoint}${separator}per_page=${GH_API_PAGE_SIZE}&page=${page}`;
+    const response = await execaFn("gh", ["api", paginatedEndpoint], { stdio: "pipe" });
+    const parsed = parseJsonArray(response.stdout, context);
+    all.push(...parsed);
+
+    if (parsed.length < GH_API_PAGE_SIZE) {
+      break;
+    }
+  }
+
+  return all;
+}
+
+async function listRepositoryLabelNames(execaFn: ExecaFn, repo: string): Promise<string[]> {
+  const rows = await listPaginatedGhApiRecords(execaFn, `repos/${repo}/labels`, "gh labels");
+  return parseRepositoryLabelNames(rows);
+}
+
+async function listRepositoryMilestoneTitles(execaFn: ExecaFn, repo: string): Promise<string[]> {
+  const rows = await listPaginatedGhApiRecords(execaFn, `repos/${repo}/milestones?state=all`, "gh milestones");
+  return parseMilestoneTitles(rows);
+}
+
+async function listRepositoryIssues(execaFn: ExecaFn, repo: string): Promise<TrackerIssueSnapshot[]> {
+  const rows = await listPaginatedGhApiRecords(execaFn, `repos/${repo}/issues?state=all`, "gh issues");
+  return parseIssueSnapshotsFromApiRows(rows);
+}
+
+function canonicalizeModuleLabel(input: string, moduleLabelMap: Map<string, string>): string {
+  const normalized = normalizeTrackerLabelName(input);
+  return moduleLabelMap.get(normalized) ?? normalized;
+}
+
+function canonicalizeMilestoneTitle(
+  input: string,
+  milestoneTitleMap: Map<string, string>,
+): string | null {
+  const normalized = normalizeMilestoneTitle(input);
+  return milestoneTitleMap.get(normalized) ?? null;
 }
 
 export function selectMissingTrackerMilestones(existingTitles: Iterable<string>): TrackerMilestoneDefinition[] {
@@ -119,4 +751,269 @@ export async function writeTrackerBootstrapMarker(nameWithOwner: string, cwd: st
 
   await writeFile(markerPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
   return markerPath;
+}
+
+export async function runTrackerReconcile(
+  options: TrackerReconcileOptions,
+  dependencies: TrackerReconcileDependencies = {},
+): Promise<TrackerReconcileResult> {
+  const execaFn = dependencies.execaFn ?? execa;
+  const promptFn = dependencies.promptFn;
+  const isInteractive = dependencies.isInteractive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+
+  const fallbackModuleRaw = typeof options.fallbackModule === "string" ? options.fallbackModule.trim() : "";
+  const fallbackModule = fallbackModuleRaw ? normalizeModuleLabel(fallbackModuleRaw) : null;
+  if (fallbackModuleRaw && !fallbackModule) {
+    throw new Error("tracker reconcile: --fallback-module must be a non-empty module label/name.");
+  }
+
+  const fallbackMilestoneRaw = typeof options.fallbackMilestone === "string" ? options.fallbackMilestone.trim() : "";
+
+  const repo = await resolveRepoNameWithOwner(execaFn);
+  const [labelNames, milestoneTitles, allIssues] = await Promise.all([
+    listRepositoryLabelNames(execaFn, repo),
+    listRepositoryMilestoneTitles(execaFn, repo),
+    listRepositoryIssues(execaFn, repo),
+  ]);
+
+  const moduleLabelMap = extractModuleLabelMap(labelNames);
+  const milestoneTitleMap = new Map<string, string>();
+  for (const title of milestoneTitles) {
+    const key = normalizeMilestoneTitle(title);
+    if (!milestoneTitleMap.has(key)) {
+      milestoneTitleMap.set(key, title);
+    }
+  }
+
+  let fallbackMilestone: string | null = null;
+  if (fallbackMilestoneRaw) {
+    fallbackMilestone = canonicalizeMilestoneTitle(fallbackMilestoneRaw, milestoneTitleMap);
+    if (!fallbackMilestone) {
+      throw new Error(`tracker reconcile: --fallback-milestone '${fallbackMilestoneRaw}' does not exist in repository.`);
+    }
+  }
+
+  const trainingIssues = allIssues.filter((issue) => issueModuleLabels(issue).length > 0);
+  const moduleProfiles = buildModuleProfiles(moduleLabelMap, trainingIssues);
+  const milestoneCountsByModule = buildMilestoneCountsByModule(trainingIssues, moduleLabelMap);
+
+  const openIssues = allIssues
+    .filter((issue) => issue.state === "open")
+    .slice()
+    .sort((left, right) => left.number - right.number);
+
+  const issueUpdates: TrackerReconcileIssueUpdate[] = [];
+  const unresolvedIssueIds: number[] = [];
+  const missingDecisionIssueIds = new Set<number>();
+  const labelsToCreate = new Set<string>();
+
+  for (const issue of openIssues) {
+    const existingModuleLower = issueModuleLabels(issue);
+    const existingModules = Array.from(new Set(existingModuleLower.map((label) => canonicalizeModuleLabel(label, moduleLabelMap)))).sort(
+      (left, right) => left.localeCompare(right),
+    );
+
+    const missingModule = existingModules.length === 0;
+    const missingMilestone = !issue.milestone;
+    if (!missingModule && !missingMilestone) {
+      continue;
+    }
+
+    let addModules: string[] = [];
+    let moduleSource: TrackerReconcileIssueUpdate["moduleSource"] = missingModule ? "none" : "existing";
+    let moduleConfidence: number | null = null;
+    const notes: string[] = [];
+
+    if (missingModule) {
+      const inferredModules = inferModules(issue, moduleProfiles);
+      if (inferredModules.modules.length > 0) {
+        addModules = inferredModules.modules.map((moduleLower) => canonicalizeModuleLabel(moduleLower, moduleLabelMap));
+        moduleSource = inferredModules.source;
+        moduleConfidence = inferredModules.confidence;
+      } else if (fallbackModule) {
+        const canonical = canonicalizeModuleLabel(fallbackModule, moduleLabelMap);
+        addModules = [canonical];
+        moduleSource = "fallback";
+      } else if (!options.dryRun && isInteractive && promptFn) {
+        const promptValue = await promptFn({
+          kind: "module",
+          issueNumber: issue.number,
+          issueTitle: issue.title,
+          suggestions: inferredModules.suggestions.map((moduleLower) => canonicalizeModuleLabel(moduleLower, moduleLabelMap)),
+        });
+
+        const normalizedPromptModule = typeof promptValue === "string" ? normalizeModuleLabel(promptValue) : null;
+        if (normalizedPromptModule) {
+          const canonical = canonicalizeModuleLabel(normalizedPromptModule, moduleLabelMap);
+          addModules = [canonical];
+          moduleSource = "prompt";
+          notes.push("module selected via prompt");
+        } else {
+          missingDecisionIssueIds.add(issue.number);
+          unresolvedIssueIds.push(issue.number);
+          notes.push("module unresolved: prompt did not return a module label");
+        }
+      } else {
+        missingDecisionIssueIds.add(issue.number);
+        unresolvedIssueIds.push(issue.number);
+        notes.push("module unresolved: provide --fallback-module or run interactively");
+      }
+    }
+
+    for (const moduleLabel of addModules) {
+      const normalized = normalizeTrackerLabelName(moduleLabel);
+      if (!moduleLabelMap.has(normalized)) {
+        labelsToCreate.add(normalized);
+      }
+    }
+
+    const effectiveModules = Array.from(new Set([...existingModules, ...addModules].map(normalizeTrackerLabelName))).sort((a, b) =>
+      a.localeCompare(b),
+    );
+
+    let setMilestone: string | null = null;
+    let milestoneSource: TrackerReconcileIssueUpdate["milestoneSource"] = missingMilestone ? "none" : "existing";
+    let milestoneConfidence: number | null = null;
+
+    if (missingMilestone) {
+      const inferredMilestone = inferMilestone(effectiveModules, milestoneCountsByModule);
+      if (inferredMilestone.milestone) {
+        setMilestone = inferredMilestone.milestone;
+        milestoneSource = "inferred";
+        milestoneConfidence = inferredMilestone.confidence;
+      } else if (fallbackMilestone) {
+        setMilestone = fallbackMilestone;
+        milestoneSource = "fallback";
+      } else if (!options.dryRun && isInteractive && promptFn && milestoneTitles.length > 0) {
+        const promptValue = await promptFn({
+          kind: "milestone",
+          issueNumber: issue.number,
+          issueTitle: issue.title,
+          suggestions: inferredMilestone.suggestions.length ? inferredMilestone.suggestions : milestoneTitles,
+        });
+
+        const canonicalMilestone = typeof promptValue === "string" ? canonicalizeMilestoneTitle(promptValue, milestoneTitleMap) : null;
+        if (canonicalMilestone) {
+          setMilestone = canonicalMilestone;
+          milestoneSource = "prompt";
+          notes.push("milestone selected via prompt");
+        } else {
+          missingDecisionIssueIds.add(issue.number);
+          if (!unresolvedIssueIds.includes(issue.number)) {
+            unresolvedIssueIds.push(issue.number);
+          }
+          notes.push("milestone unresolved: prompt did not match an existing milestone");
+        }
+      } else {
+        missingDecisionIssueIds.add(issue.number);
+        if (!unresolvedIssueIds.includes(issue.number)) {
+          unresolvedIssueIds.push(issue.number);
+        }
+        notes.push("milestone unresolved: provide --fallback-milestone or run interactively");
+      }
+    }
+
+    const canonicalAddModules = addModules
+      .map((label) => canonicalizeModuleLabel(label, moduleLabelMap))
+      .filter((label) => !existingModules.some((current) => normalizeTrackerLabelName(current) === normalizeTrackerLabelName(label)));
+
+    const nextAddModules = Array.from(new Set(canonicalAddModules.map(normalizeTrackerLabelName)))
+      .map((normalized) => moduleLabelMap.get(normalized) ?? normalized)
+      .sort((left, right) => left.localeCompare(right));
+
+    if (!nextAddModules.length && !setMilestone) {
+      continue;
+    }
+
+    issueUpdates.push({
+      issueNumber: issue.number,
+      issueTitle: issue.title,
+      addLabels: nextAddModules,
+      setMilestone,
+      moduleSource,
+      moduleConfidence,
+      milestoneSource,
+      milestoneConfidence,
+      notes,
+    });
+  }
+
+  let degradedToPlanOnly = false;
+  let planOnlyReason: string | null = null;
+
+  if (!options.dryRun && missingDecisionIssueIds.size > 0) {
+    degradedToPlanOnly = true;
+    const ids = Array.from(missingDecisionIssueIds).sort((a, b) => a - b);
+    planOnlyReason = `tracker reconcile: non-interactive plan-only mode for issues ${ids
+      .map((id) => `#${id}`)
+      .join(", ")} (provide fallbacks or run interactively).`;
+  }
+
+  const commands: string[][] = [];
+  const createdLabels: string[] = [];
+
+  const labelsToCreateOrdered = Array.from(labelsToCreate)
+    .filter((label) => !moduleLabelMap.has(label))
+    .sort((left, right) => left.localeCompare(right));
+
+  for (const labelLower of labelsToCreateOrdered) {
+    const definition = buildGeneratedModuleLabelDefinition(labelLower);
+    commands.push(["label", "create", definition.name, "--color", definition.color, "--description", definition.description]);
+  }
+
+  for (const update of issueUpdates) {
+    const args = ["issue", "edit", String(update.issueNumber)];
+    if (update.setMilestone) {
+      args.push("--milestone", update.setMilestone);
+    }
+    if (update.addLabels.length > 0) {
+      args.push("--add-label", update.addLabels.join(","));
+    }
+    commands.push(args);
+  }
+
+  const shouldApply = !options.dryRun && !degradedToPlanOnly;
+
+  if (shouldApply) {
+    for (const labelLower of labelsToCreateOrdered) {
+      const definition = buildGeneratedModuleLabelDefinition(labelLower);
+      await execaFn(
+        "gh",
+        ["label", "create", definition.name, "--color", definition.color, "--description", definition.description],
+        { stdio: "inherit" },
+      );
+      moduleLabelMap.set(labelLower, definition.name);
+      createdLabels.push(definition.name);
+    }
+
+    for (const update of issueUpdates) {
+      const args = ["issue", "edit", String(update.issueNumber)];
+      if (update.setMilestone) {
+        args.push("--milestone", update.setMilestone);
+      }
+      if (update.addLabels.length > 0) {
+        const canonicalLabels = update.addLabels
+          .map((label) => {
+            const normalized = normalizeTrackerLabelName(label);
+            return moduleLabelMap.get(normalized) ?? label;
+          })
+          .sort((left, right) => left.localeCompare(right));
+        args.push("--add-label", canonicalLabels.join(","));
+      }
+
+      await execaFn("gh", args, { stdio: "inherit" });
+    }
+  }
+
+  return {
+    repo,
+    dryRun: options.dryRun,
+    applied: shouldApply,
+    degradedToPlanOnly,
+    planOnlyReason,
+    issueUpdates,
+    unresolvedIssueIds: Array.from(new Set(unresolvedIssueIds)).sort((a, b) => a - b),
+    createdLabels,
+    commands,
+  };
 }

--- a/tests/cli-tracker.test.ts
+++ b/tests/cli-tracker.test.ts
@@ -7,6 +7,85 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createProgram } from "../src/cli-program";
 import { getTrackerBootstrapMarkerPath } from "../src/core/tracker";
 
+type ApiIssueInput = {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: string[];
+  milestone: string | null;
+  body?: string;
+};
+
+function apiIssue(input: ApiIssueInput): Record<string, unknown> {
+  return {
+    number: input.number,
+    title: input.title,
+    state: input.state,
+    labels: input.labels.map((name) => ({ name })),
+    milestone: input.milestone ? { title: input.milestone } : null,
+    body: input.body ?? "",
+  };
+}
+
+function createReconcileCliExecaMock(data: {
+  repo: string;
+  labels: string[];
+  milestones: string[];
+  issues: Record<string, unknown>[];
+  failOn?: "labels" | "milestones" | "issues";
+}) {
+  return vi.fn(async (_cmd: string, args: string[]) => {
+    if (args[0] === "repo" && args[1] === "view") {
+      return { stdout: `${data.repo}\n` };
+    }
+
+    if (args[0] === "api") {
+      const endpoint = args[1] ?? "";
+
+      if (data.failOn === "labels" && endpoint.startsWith(`repos/${data.repo}/labels?`)) {
+        throw new Error("labels unavailable");
+      }
+      if (data.failOn === "milestones" && endpoint.startsWith(`repos/${data.repo}/milestones?`)) {
+        throw new Error("milestones unavailable");
+      }
+      if (data.failOn === "issues" && endpoint.startsWith(`repos/${data.repo}/issues?`)) {
+        throw new Error("issues unavailable");
+      }
+
+      if (endpoint === `repos/${data.repo}/labels?per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.labels.map((name) => ({ name }))) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/labels?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+
+      if (endpoint === `repos/${data.repo}/milestones?state=all&per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.milestones.map((title) => ({ title }))) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/milestones?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+
+      if (endpoint === `repos/${data.repo}/issues?state=all&per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.issues) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/issues?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+    }
+
+    if (args[0] === "issue" && args[1] === "edit") {
+      return { stdout: "" };
+    }
+
+    if (args[0] === "label" && args[1] === "create") {
+      return { stdout: "" };
+    }
+
+    return { stdout: "" };
+  });
+}
+
 describe.sequential("cli tracker bootstrap", () => {
   const originalCwd = process.cwd();
   let tempDir = "";
@@ -176,5 +255,200 @@ describe.sequential("cli tracker bootstrap", () => {
     expect(logs.some((line) => line.includes("Tracker bootstrap suggested:"))).toBe(true);
     expect(logs.some((line) => line.includes("Run: node dist/cli.cjs tracker bootstrap --dry-run"))).toBe(true);
     expect(logs.some((line) => line.includes("Then: node dist/cli.cjs tracker bootstrap"))).toBe(true);
+  });
+});
+
+describe.sequential("cli tracker reconcile", () => {
+  const originalCwd = process.cwd();
+  let tempDir = "";
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "vibe-cli-tracker-reconcile-test-"));
+    process.chdir(tempDir);
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("applies reconcile updates by default", async () => {
+    const logs: string[] = [];
+    const execaMock = createReconcileCliExecaMock({
+      repo: "acme/demo",
+      labels: ["module:billing"],
+      milestones: ["Q1"],
+      issues: [
+        apiIssue({
+          number: 1,
+          title: "Billing checkout issue",
+          state: "closed",
+          labels: ["module:billing"],
+          milestone: "Q1",
+          body: "checkout billing",
+        }),
+        apiIssue({
+          number: 20,
+          title: "Checkout billing failure",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "billing checkout",
+        }),
+      ],
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "tracker", "reconcile"]);
+
+    const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
+    expect(commands.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit" && args[2] === "20")).toBe(true);
+    expect(logs.some((line) => line.includes("tracker reconcile: DONE"))).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints plan without mutating in dry-run mode", async () => {
+    const logs: string[] = [];
+    const execaMock = createReconcileCliExecaMock({
+      repo: "acme/demo",
+      labels: ["module:billing"],
+      milestones: ["Q1"],
+      issues: [
+        apiIssue({
+          number: 1,
+          title: "Billing checkout issue",
+          state: "closed",
+          labels: ["module:billing"],
+          milestone: "Q1",
+          body: "checkout billing",
+        }),
+        apiIssue({
+          number: 21,
+          title: "Checkout billing failure",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "billing checkout",
+        }),
+      ],
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "tracker", "reconcile", "--dry-run"]);
+
+    const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
+    expect(commands.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit")).toBe(false);
+    expect(logs.some((line) => line.includes("tracker reconcile: dry-run complete."))).toBe(true);
+    expect(logs.some((line) => line.includes("$ gh issue edit 21"))).toBe(true);
+  });
+
+  it("uses fallback flags and creates missing module labels", async () => {
+    const logs: string[] = [];
+    const execaMock = createReconcileCliExecaMock({
+      repo: "acme/demo",
+      labels: ["module:existing"],
+      milestones: ["Roadmap"],
+      issues: [
+        apiIssue({
+          number: 30,
+          title: "Ambiguous setup",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "no clear scope",
+        }),
+      ],
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync([
+      "node",
+      "vibe",
+      "tracker",
+      "reconcile",
+      "--fallback-module",
+      "module:platform",
+      "--fallback-milestone",
+      "Roadmap",
+    ]);
+
+    const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
+    expect(commands.some(([cmd, args]) => cmd === "gh" && args[0] === "label" && args[1] === "create" && args[2] === "module:platform")).toBe(
+      true,
+    );
+    expect(commands.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit" && args[2] === "30")).toBe(true);
+    expect(logs.some((line) => line.includes("tracker reconcile: DONE"))).toBe(true);
+  });
+
+  it("degrades to plan-only in non-interactive mode when fallbacks are missing", async () => {
+    const logs: string[] = [];
+    const execaMock = createReconcileCliExecaMock({
+      repo: "acme/demo",
+      labels: ["module:ops"],
+      milestones: ["Ops"],
+      issues: [
+        apiIssue({
+          number: 40,
+          title: "Unknown generic task",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "ambiguous request",
+        }),
+      ],
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "tracker", "reconcile"]);
+
+    const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
+    expect(commands.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit")).toBe(false);
+    expect(logs.some((line) => line.includes("plan-only mode"))).toBe(true);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("returns exit 1 on operational errors", async () => {
+    const execaMock = createReconcileCliExecaMock({
+      repo: "acme/demo",
+      labels: [],
+      milestones: [],
+      issues: [],
+      failOn: "issues",
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "tracker", "reconcile"]);
+
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/tests/tracker.test.ts
+++ b/tests/tracker.test.ts
@@ -2,15 +2,104 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getTrackerBootstrapMarkerPath,
+  runTrackerReconcile,
+  sanitizeTrackerText,
   selectMissingTrackerLabels,
   selectMissingTrackerMilestones,
   shouldSuggestTrackerBootstrap,
   writeTrackerBootstrapMarker,
 } from "../src/core/tracker";
+
+type ApiIssueInput = {
+  number: number;
+  title: string;
+  state: "open" | "closed";
+  labels: string[];
+  milestone: string | null;
+  body?: string;
+};
+
+function apiIssue(input: ApiIssueInput): Record<string, unknown> {
+  return {
+    number: input.number,
+    title: input.title,
+    state: input.state,
+    labels: input.labels.map((name) => ({ name })),
+    milestone: input.milestone ? { title: input.milestone } : null,
+    body: input.body ?? "",
+  };
+}
+
+function createTrackerReconcileExecaMock(data: {
+  repo: string;
+  labels: string[];
+  milestones: string[];
+  issues: Record<string, unknown>[];
+}) {
+  const calls: Array<[string, string[]]> = [];
+
+  const execaMock = vi.fn(async (cmd: string, args: string[]) => {
+    calls.push([cmd, args]);
+
+    if (cmd !== "gh") {
+      return { stdout: "" };
+    }
+
+    if (
+      args[0] === "repo" &&
+      args[1] === "view" &&
+      args[2] === "--json" &&
+      args[3] === "nameWithOwner" &&
+      args[4] === "-q" &&
+      args[5] === ".nameWithOwner"
+    ) {
+      return { stdout: `${data.repo}\n` };
+    }
+
+    if (args[0] === "api") {
+      const endpoint = args[1] ?? "";
+
+      if (endpoint === `repos/${data.repo}/labels?per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.labels.map((name) => ({ name }))) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/labels?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+
+      if (endpoint === `repos/${data.repo}/milestones?state=all&per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.milestones.map((title) => ({ title }))) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/milestones?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+
+      if (endpoint === `repos/${data.repo}/issues?state=all&per_page=100&page=1`) {
+        return { stdout: JSON.stringify(data.issues) };
+      }
+      if (endpoint.startsWith(`repos/${data.repo}/issues?`) && !endpoint.endsWith("page=1")) {
+        return { stdout: "[]" };
+      }
+
+      throw new Error(`Unexpected gh api endpoint: ${endpoint}`);
+    }
+
+    if (args[0] === "label" && args[1] === "create") {
+      return { stdout: "" };
+    }
+
+    if (args[0] === "issue" && args[1] === "edit") {
+      return { stdout: "" };
+    }
+
+    throw new Error(`Unexpected gh command: ${args.join(" ")}`);
+  });
+
+  return { execaMock, calls };
+}
 
 describe.sequential("tracker bootstrap core", () => {
   const originalCwd = process.cwd();
@@ -23,6 +112,7 @@ describe.sequential("tracker bootstrap core", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    vi.restoreAllMocks();
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -58,5 +148,289 @@ describe.sequential("tracker bootstrap core", () => {
     expect(payload.repository).toBe("acme/demo");
     expect(Array.isArray(payload.milestones)).toBe(true);
     expect(Array.isArray(payload.labels)).toBe(true);
+  });
+});
+
+describe.sequential("tracker reconcile core", () => {
+  it("sanitizes markdown/code/url noise before tokenization", () => {
+    const cleaned = sanitizeTrackerText("Fix docs https://example.com ```ts\nconst x = 1\n``` now");
+    expect(cleaned).toContain("fix docs");
+    expect(cleaned).not.toContain("https://example.com");
+    expect(cleaned).not.toContain("const x");
+  });
+
+  it("infers module/milestone from repo history using title/body signals", async () => {
+    const { execaMock } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:billing", "module:infra", "status:backlog"],
+      milestones: ["Q1", "Infra"],
+      issues: [
+        apiIssue({
+          number: 1,
+          title: "Billing checkout retries",
+          state: "closed",
+          labels: ["module:billing"],
+          milestone: "Q1",
+          body: "Handle checkout retry flows and payment tokenization",
+        }),
+        apiIssue({
+          number: 2,
+          title: "Checkout payment validation",
+          state: "closed",
+          labels: ["module:billing"],
+          milestone: "Q1",
+          body: "Validation rules for checkout",
+        }),
+        apiIssue({
+          number: 3,
+          title: "Terraform cluster upgrade",
+          state: "closed",
+          labels: ["module:infra"],
+          milestone: "Infra",
+          body: "Upgrade kubernetes control plane",
+        }),
+        apiIssue({
+          number: 10,
+          title: "Checkout token fails intermittently",
+          state: "open",
+          labels: ["bug"],
+          milestone: null,
+          body: "Investigate token handling. https://example.com/details",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: true,
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.issueUpdates).toHaveLength(1);
+    expect(result.issueUpdates[0]?.issueNumber).toBe(10);
+    expect(result.issueUpdates[0]?.addLabels).toEqual(["module:billing"]);
+    expect(result.issueUpdates[0]?.setMilestone).toBe("Q1");
+    expect(result.issueUpdates[0]?.milestoneSource).toBe("inferred");
+  });
+
+  it("adds multiple modules when explicit matches are present", async () => {
+    const { execaMock } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:api", "module:web"],
+      milestones: ["Release"],
+      issues: [
+        apiIssue({
+          number: 20,
+          title: "Sync api and web authentication contracts",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "Coordinate api schema changes with web flow updates",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: true,
+        fallbackMilestone: "Release",
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.issueUpdates).toHaveLength(1);
+    expect(result.issueUpdates[0]?.addLabels).toEqual(["module:api", "module:web"]);
+  });
+
+  it("does not auto-assign module when score ratio is below threshold and degrades to plan-only in non-interactive apply", async () => {
+    const { execaMock, calls } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:alpha", "module:beta"],
+      milestones: ["M1"],
+      issues: [
+        apiIssue({
+          number: 1,
+          title: "shared alpha context",
+          state: "closed",
+          labels: ["module:alpha"],
+          milestone: "M1",
+          body: "shared",
+        }),
+        apiIssue({
+          number: 2,
+          title: "shared beta context",
+          state: "closed",
+          labels: ["module:beta"],
+          milestone: "M1",
+          body: "shared",
+        }),
+        apiIssue({
+          number: 30,
+          title: "shared context only",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "shared",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: false,
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.degradedToPlanOnly).toBe(true);
+    expect(result.applied).toBe(false);
+    expect(result.unresolvedIssueIds).toEqual([30]);
+    expect(calls.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit")).toBe(false);
+  });
+
+  it("uses fallback milestone when inferred confidence is below 80%", async () => {
+    const { execaMock } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:data"],
+      milestones: ["Data V1", "Data V2"],
+      issues: [
+        apiIssue({
+          number: 1,
+          title: "Data ingestion pipeline",
+          state: "closed",
+          labels: ["module:data"],
+          milestone: "Data V1",
+          body: "ingestion",
+        }),
+        apiIssue({
+          number: 2,
+          title: "Data retention cleanup",
+          state: "closed",
+          labels: ["module:data"],
+          milestone: "Data V1",
+          body: "cleanup",
+        }),
+        apiIssue({
+          number: 3,
+          title: "Data schema migration",
+          state: "closed",
+          labels: ["module:data"],
+          milestone: "Data V1",
+          body: "schema",
+        }),
+        apiIssue({
+          number: 4,
+          title: "Data export fallback",
+          state: "closed",
+          labels: ["module:data"],
+          milestone: "Data V2",
+          body: "export",
+        }),
+        apiIssue({
+          number: 40,
+          title: "Data integrity alarms",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "data alarms",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: true,
+        fallbackMilestone: "Data V1",
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.issueUpdates).toHaveLength(1);
+    expect(result.issueUpdates[0]?.setMilestone).toBe("Data V1");
+    expect(result.issueUpdates[0]?.milestoneSource).toBe("fallback");
+  });
+
+  it("creates and assigns fallback module labels when missing from repository taxonomy", async () => {
+    const { execaMock, calls } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:existing"],
+      milestones: ["Roadmap"],
+      issues: [
+        apiIssue({
+          number: 50,
+          title: "new platform setup",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "bootstrap platform",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: false,
+        fallbackModule: "module:platform",
+        fallbackMilestone: "Roadmap",
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.applied).toBe(true);
+    expect(result.createdLabels).toEqual(["module:platform"]);
+    expect(calls.some(([cmd, args]) => cmd === "gh" && args[0] === "label" && args[1] === "create" && args[2] === "module:platform")).toBe(
+      true,
+    );
+    expect(calls.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit" && args[2] === "50")).toBe(true);
+  });
+
+  it("keeps exit-safe plan-only mode when decisions are missing without TTY", async () => {
+    const { execaMock, calls } = createTrackerReconcileExecaMock({
+      repo: "acme/demo",
+      labels: ["module:ops"],
+      milestones: ["Ops"],
+      issues: [
+        apiIssue({
+          number: 60,
+          title: "Unknown ambiguous work",
+          state: "open",
+          labels: [],
+          milestone: null,
+          body: "generic request with no strong hints",
+        }),
+      ],
+    });
+
+    const result = await runTrackerReconcile(
+      {
+        dryRun: false,
+      },
+      {
+        execaFn: execaMock as never,
+        isInteractive: false,
+      },
+    );
+
+    expect(result.degradedToPlanOnly).toBe(true);
+    expect(result.applied).toBe(false);
+    expect(result.planOnlyReason).toContain("non-interactive plan-only mode");
+    expect(calls.some(([cmd, args]) => cmd === "gh" && args[0] === "issue" && args[1] === "edit")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Issue: #27 feat: add tracker reconcile to autofill missing milestone/module labels
- Branch: `codex/issue-27-tracker-reconcile`
- Added `vibe tracker reconcile` to fill missing `module:*` labels and milestones on open issues.
- Implemented repo-agnostic classification learned from repo taxonomy/history (`labels`, `title`, `body`) with configurable fallbacks.
- Added non-interactive safety: if unresolved metadata requires input, command degrades to plan-only and exits `0`.
- Extended test suite for core/CLI reconcile behavior and updated README command reference.

## Architecture decisions
- Keep reconcile logic in `src/core/tracker.ts` as a cohesive tracker domain module to reuse existing bootstrap utilities and pagination helpers.
- Use issue-history-derived module profiles instead of hardcoded module maps so behavior generalizes across external repos.
- Treat reconcile as append-only metadata completion: add missing labels/milestone only; never remove existing issue metadata.
- Separate planning and execution in one run result (`commands`, `degradedToPlanOnly`, `applied`) to keep dry-run and non-interactive behavior explicit.

## Why these decisions were made
- Repo-agnostic operation is required for `.vibe` adoption in arbitrary repositories, so static `module:cli/ui/...` heuristics were removed.
- Learning from existing labeled issues gives deterministic local context while avoiding external dependencies.
- Degrading to plan-only in non-interactive contexts prevents accidental misclassification while preserving pipeline stability.
- Explicit thresholds (`1.5x` module ratio, `>=80%` milestone confidence) keep autopopulation conservative and auditable.

## Alternatives considered / rejected
- Hardcoding vibe module taxonomy in reconcile: rejected because it does not transfer to non-vibe repos.
- Failing non-interactive runs when decisions are missing: rejected to avoid breaking automation loops.
- Always prompting milestone/module even with strong signals: rejected due to poor UX and reduced automation value.

## Validation
- `pnpm test`
- `pnpm build`

Fixes #27
