### PR TITLE
#58 chore: audit closure artifacts and tracker close-out

### DIFF
--- a/.vibe/reviews/58/implementation.md
+++ b/.vibe/reviews/58/implementation.md
@@ -1,0 +1,24 @@
+# Implementation Pass
+
+## Scope
+- Audit-only closure for issue #58 (follow-up findings from issue #56 / PR #57).
+
+## What I verified
+- Confirmed `/Users/lucasgday/code/codex/vibe-backlog/src/core/pr-ready.ts` handles `git ls-remote` failures as structured `head-sync` check failures (`NOT READY`) without hard-throwing from the readiness check path.
+- Confirmed readiness blocks CLOSED PR state (`pr-open` fail) and draft PR state (`pr-not-draft` fail) in `/Users/lucasgday/code/codex/vibe-backlog/src/core/pr-ready.ts`.
+- Confirmed focused regression coverage exists in `/Users/lucasgday/code/codex/vibe-backlog/tests/pr-ready.test.ts` and CLI behavior coverage in `/Users/lucasgday/code/codex/vibe-backlog/tests/cli-pr-ready.test.ts`.
+
+## Commands run
+- `pnpm test tests/pr-ready.test.ts tests/cli-pr-ready.test.ts`
+- `pnpm test`
+- `pnpm build`
+
+## Result
+- All validations passed on `2026-02-18`.
+- No additional code change is required to resolve the two original #58 findings.
+
+## Residual risk
+- Handling of transient GitHub API connectivity errors in `pr ready` remains out of scope for #58 and is deferred to issue #59.
+
+## Findings
+- none

--- a/.vibe/reviews/58/ops.md
+++ b/.vibe/reviews/58/ops.md
@@ -1,0 +1,22 @@
+# Ops Pass
+
+## Operational readiness
+- Scope is audit/closure only; no code-path mutation and no dependency changes.
+- Validation commands are deterministic and repo-local.
+
+## Workflow checks
+- `pnpm test tests/pr-ready.test.ts tests/cli-pr-ready.test.ts`
+- `pnpm test`
+- `pnpm build`
+- `node dist/cli.cjs postflight`
+- `node dist/cli.cjs postflight --apply`
+
+## Release impact
+- None. This turn updates review artifacts and tracker state for issue closure.
+- Tracker synchronization applied successfully: removed `status:backlog`, added `status:done`, and closed issue `#58`.
+
+## Residual operational risk
+- Tracker apply can be affected by transient GitHub connectivity; if apply fails, rerun `node dist/cli.cjs postflight --apply` without forcing manual inconsistent updates.
+
+## Findings
+- none

--- a/.vibe/reviews/58/quality.md
+++ b/.vibe/reviews/58/quality.md
@@ -1,0 +1,26 @@
+# Quality Pass
+
+## What I tested
+- `pnpm test tests/pr-ready.test.ts tests/cli-pr-ready.test.ts`
+- `pnpm test`
+- `pnpm build`
+
+## Coverage confirmed
+- `/Users/lucasgday/code/codex/vibe-backlog/tests/pr-ready.test.ts`
+  - structured `git ls-remote` failure handling (`NOT READY` / `head-sync` detail)
+  - PR `CLOSED` blocking behavior
+  - PR `isDraft=true` blocking behavior
+- `/Users/lucasgday/code/codex/vibe-backlog/tests/cli-pr-ready.test.ts`
+  - CLI READY output and freeze guidance
+  - CLI NOT READY output with remediation command
+  - CLI argument validation (`--pr`)
+
+## Result
+- Focused regressions and full test suite passed.
+- Build succeeded with no additional code modifications required for #58.
+
+## Remaining untested
+- Live network/API instability behavior for `gh pr view` (outside #58 scope).
+
+## Findings
+- none

--- a/.vibe/reviews/58/security.md
+++ b/.vibe/reviews/58/security.md
@@ -1,0 +1,20 @@
+# Security Pass
+
+## Threat model quick scan
+- `pr ready` is a read-only merge readiness gate; the primary risk is false readiness under operational failure paths (remote head lookup, PR state checks, or stale review evidence).
+- The original #58 findings were focused on fail-closed behavior and missing blocking-state regression coverage.
+
+## What I verified
+- Remote-head lookup failure in `/Users/lucasgday/code/codex/vibe-backlog/src/core/pr-ready.ts` is fail-closed and reported as `head-sync` failure detail, not a readiness pass.
+- CLOSED and draft PR states are explicit blocking checks in readiness evaluation.
+- Regression tests validating those cases are present and passing in `/Users/lucasgday/code/codex/vibe-backlog/tests/pr-ready.test.ts`.
+
+## Result
+- No new AppSec issues found in the audited scope.
+- Security posture for the #58 scope is fail-closed and deterministic.
+
+## Residual risk
+- Connectivity failures to GitHub APIs can still surface as command-level errors in some paths; improvement is intentionally deferred beyond #58 scope.
+
+## Findings
+- none


### PR DESCRIPTION
## Summary
- add implementation/security/quality/ops pass logs under .vibe/reviews/58
- validate #58 follow-up findings remain resolved via focused + full test/build runs
- apply postflight tracker updates to mark done and close #58

## Validation
- pnpm test tests/pr-ready.test.ts tests/cli-pr-ready.test.ts
- pnpm test
- pnpm build
- node dist/cli.cjs postflight
- node dist/cli.cjs postflight --apply

Fixes #58