### PR TITLE
#97 feat(metrics): expose README workflow scaffold adoption signal in JSON output

### DIFF
--- a/.vibe/reviews/97/growth.md
+++ b/.vibe/reviews/97/growth.md
@@ -27,3 +27,15 @@ No blockers from growth perspective; new field is a useful signal with clear fut
 
 ### Findings
 - [P2] Adoption metric is not directly measurable with current status mapping (src/core/init.ts:503)
+
+## Run 2026-03-02T12:57:45.984Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No growth blockers found. The updated status semantics now support clearer activation/adoption instrumentation for README workflow scaffold behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/97/growth.md
+++ b/.vibe/reviews/97/growth.md
@@ -15,3 +15,15 @@ No blockers from growth perspective; new field is a useful signal with clear fut
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:55:10.145Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 growth/instrumentation issue found in the current status taxonomy.
+
+### Findings
+- [P2] Adoption metric is not directly measurable with current status mapping (src/core/init.ts:503)

--- a/.vibe/reviews/97/growth.md
+++ b/.vibe/reviews/97/growth.md
@@ -1,0 +1,17 @@
+## Run 2026-03-02T12:51:18Z
+Growth/learning opportunities:
+- `readme_workflow_status` enables lightweight adoption telemetry for scaffold hygiene without parsing diff output.
+- Follow-up opportunity: aggregate status counts in a future `status`/analytics summary to quantify README scaffold drift and repair frequency across repos.
+- Instrumentation gap: no historical trend persistence for this field yet; currently it is single-run output only.
+
+## Run 2026-03-02T12:51:18Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No blockers from growth perspective; new field is a useful signal with clear future aggregation potential.
+
+### Findings
+- none

--- a/.vibe/reviews/97/implementation.md
+++ b/.vibe/reviews/97/implementation.md
@@ -1,0 +1,24 @@
+## Run 2026-03-02T12:51:18Z
+- Scope: issue #97 (`feat(metrics): expose README workflow scaffold adoption signal in JSON output`).
+- Changes:
+  - Added `readme_workflow_status` to `VibeScaffoldUpdateResult` with enum values: `created`, `updated`, `unchanged`, `repaired`.
+  - Updated README workflow upsert logic to return deterministic status across create/refresh/no-op/marker-repair scenarios.
+  - Wired `applyVibeScaffoldUpdate` to expose the status in `update --json` payloads.
+  - Added regression tests for all four status outcomes in `tests/cli-update.test.ts`.
+  - Documented the new JSON field in README.
+- Files:
+  - `src/core/init.ts`
+  - `tests/cli-update.test.ts`
+  - `README.md`
+
+## Run 2026-03-02T12:51:18Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects found after adding `readme_workflow_status` plumbing and tests.
+
+### Findings
+- none

--- a/.vibe/reviews/97/implementation.md
+++ b/.vibe/reviews/97/implementation.md
@@ -34,3 +34,15 @@ No implementation defects found after adding `readme_workflow_status` plumbing a
 
 ### Findings
 - [P2] `readme_workflow_status` conflates first-time insertion with routine refresh (src/core/init.ts:503)
+
+## Run 2026-03-02T12:57:45.982Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects found in the current diff; `readme_workflow_status` now cleanly separates first-time creation, refresh, unchanged, and repair paths.
+
+### Findings
+- none

--- a/.vibe/reviews/97/implementation.md
+++ b/.vibe/reviews/97/implementation.md
@@ -22,3 +22,15 @@ No implementation defects found after adding `readme_workflow_status` plumbing a
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:55:10.143Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 behavior-level issue found in the new status mapping for README workflow updates.
+
+### Findings
+- [P2] `readme_workflow_status` conflates first-time insertion with routine refresh (src/core/init.ts:503)

--- a/.vibe/reviews/97/ops.md
+++ b/.vibe/reviews/97/ops.md
@@ -29,3 +29,15 @@ Operational risk is low; change is additive and regression-tested.
 
 ### Findings
 - [P3] README lists enum values but not their exact semantics (README.md:126)
+
+## Run 2026-03-02T12:57:45.984Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No operational issues found. Contract semantics are now documented and the change remains additive and test-backed.
+
+### Findings
+- none

--- a/.vibe/reviews/97/ops.md
+++ b/.vibe/reviews/97/ops.md
@@ -17,3 +17,15 @@ Operational risk is low; change is additive and regression-tested.
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:55:10.145Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 operational/docs clarity issue found for downstream consumers.
+
+### Findings
+- [P3] README lists enum values but not their exact semantics (README.md:126)

--- a/.vibe/reviews/97/ops.md
+++ b/.vibe/reviews/97/ops.md
@@ -1,0 +1,19 @@
+## Run 2026-03-02T12:51:18Z
+Ops/release checks:
+- Deterministic local verification completed with repo-local commands:
+  - `pnpm test`
+  - `pnpm build`
+- No dependency, CI workflow, or packaging surface changes.
+- JSON output contract change is additive (`readme_workflow_status`) and documented in README.
+
+## Run 2026-03-02T12:51:18Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Operational risk is low; change is additive and regression-tested.
+
+### Findings
+- none

--- a/.vibe/reviews/97/quality.md
+++ b/.vibe/reviews/97/quality.md
@@ -25,3 +25,15 @@ Quality coverage is sufficient for this scope; core and edge status paths are ex
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:55:10.144Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 test coverage gap found for the new JSON status contract.
+
+### Findings
+- [P3] Missing JSON status assertion for end-only marker repair path (tests/cli-update.test.ts:458)

--- a/.vibe/reviews/97/quality.md
+++ b/.vibe/reviews/97/quality.md
@@ -1,0 +1,27 @@
+## Run 2026-03-02T12:51:18Z
+What I tested:
+- Added/update JSON coverage for README workflow status states:
+  - `created` when README is absent.
+  - `updated` when README exists without managed block.
+  - `unchanged` when scaffold is already current.
+  - `repaired` when markers are malformed.
+- Ran full repository regression tests and build.
+
+Commands:
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- Real GitHub/network behavior is out of scope for this local scaffold JSON change.
+
+## Run 2026-03-02T12:51:18Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Quality coverage is sufficient for this scope; core and edge status paths are explicitly tested.
+
+### Findings
+- none

--- a/.vibe/reviews/97/quality.md
+++ b/.vibe/reviews/97/quality.md
@@ -37,3 +37,15 @@ Quality coverage is sufficient for this scope; core and edge status paths are ex
 
 ### Findings
 - [P3] Missing JSON status assertion for end-only marker repair path (tests/cli-update.test.ts:458)
+
+## Run 2026-03-02T12:57:45.983Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No quality findings. Coverage now includes JSON assertions for created/updated/unchanged/repaired paths, including malformed end-marker repair behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/97/security.md
+++ b/.vibe/reviews/97/security.md
@@ -1,0 +1,21 @@
+## Run 2026-03-02T12:51:18Z
+Threat model quick scan:
+This change only adds an internal status field to local scaffold-update JSON output. Primary risks are accidental disclosure of sensitive file content or introducing malformed-state handling that could overwrite user README content.
+
+Checks and mitigations:
+- No new command execution, auth surface, or network path was introduced.
+- Status values are static literals (`created|updated|unchanged|repaired`), so payload expansion does not leak content.
+- Malformed marker handling remains marker-scoped repair logic and preserves non-managed README sections.
+- Existing marker-safe replacement behavior remains covered by CLI tests.
+
+## Run 2026-03-02T12:51:18Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No new security issues identified in this diff.
+
+### Findings
+- none

--- a/.vibe/reviews/97/security.md
+++ b/.vibe/reviews/97/security.md
@@ -19,3 +19,15 @@ No new security issues identified in this diff.
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:55:10.144Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No security-impacting changes detected in this diff.
+
+### Findings
+- none

--- a/.vibe/reviews/97/security.md
+++ b/.vibe/reviews/97/security.md
@@ -31,3 +31,15 @@ No security-impacting changes detected in this diff.
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:57:45.983Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No security-impacting changes detected; no new auth, network, command-execution, or secret-handling surface was introduced.
+
+### Findings
+- none

--- a/.vibe/reviews/97/ux.md
+++ b/.vibe/reviews/97/ux.md
@@ -23,3 +23,15 @@ No UI surface changed in this PR; under standard assumptions (8pt spacing grid, 
 
 ### Findings
 - none
+
+## Run 2026-03-02T12:57:45.984Z
+- run_id: issue-97-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No UI surface changed in this diff; assuming an 8pt spacing grid, 16px base typography, and 44px minimum hit targets, there are no design-system consistency or accessibility regressions to report.
+
+### Findings
+- none

--- a/.vibe/reviews/97/ux.md
+++ b/.vibe/reviews/97/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T12:55:10.144Z
+- run_id: issue-97-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No UI surface changed in this PR; under standard assumptions (8pt spacing grid, 16px body text baseline, 44px minimum targets), no design-system regressions are applicable.
+
+### Findings
+- none

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ vibe postflight --apply
 `preflight` also performs a best-effort, non-blocking tool version check and prints an explicit `self update` command when a newer `vibe-backlog` release is available.
 `update` checks/applies `.vibe` scaffold updates with metadata tracking in `.vibe/scaffold.json`, dry-run diff preview, and marker-safe preservation of protected sections.
 `init`/`update` also scaffold a managed README workflow section (`<!-- vibe:workflow-docs:start --> ... <!-- vibe:workflow-docs:end -->`) with a Mermaid diagram, preserving non-managed README content.
-`update --json` includes `readme_workflow_status` with one of: `created`, `updated`, `unchanged`, `repaired`.
+`update --json` includes `readme_workflow_status` with one of: `created` (workflow block created, including first insertion into an existing README), `updated` (existing managed block refreshed), `unchanged` (already up-to-date), `repaired` (malformed markers were repaired).
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
 `turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 `turn start --issue <n>` now enforces a remote-state guard (`git fetch origin`, `git status -sb`, `git branch -vv`, PR state check on current branch) and blocks branch creation on behind/diverged or closed/merged-PR branch states with explicit remediation commands.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ vibe postflight --apply
 `preflight` also performs a best-effort, non-blocking tool version check and prints an explicit `self update` command when a newer `vibe-backlog` release is available.
 `update` checks/applies `.vibe` scaffold updates with metadata tracking in `.vibe/scaffold.json`, dry-run diff preview, and marker-safe preservation of protected sections.
 `init`/`update` also scaffold a managed README workflow section (`<!-- vibe:workflow-docs:start --> ... <!-- vibe:workflow-docs:end -->`) with a Mermaid diagram, preserving non-managed README content.
+`update --json` includes `readme_workflow_status` with one of: `created`, `updated`, `unchanged`, `repaired`.
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
 `turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 `turn start --issue <n>` now enforces a remote-state guard (`git fetch origin`, `git status -sb`, `git branch -vv`, PR state check on current branch) and blocks branch creation on behind/diverged or closed/merged-PR branch states with explicit remediation commands.
@@ -485,4 +486,3 @@ Workflow steps (text fallback):
 6. Apply tracker updates with `vibe postflight --apply`.
 
 <!-- vibe:workflow-docs:end -->
-

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -43,11 +43,14 @@ export type VibeScaffoldDiffPreview = {
   preview: string;
 };
 
+export type ReadmeWorkflowStatus = "created" | "updated" | "unchanged" | "repaired";
+
 export type VibeScaffoldUpdateResult = InitScaffoldResult & {
   check: VibeScaffoldCheckResult;
   dryRun: boolean;
   applied: boolean;
   previews: VibeScaffoldDiffPreview[];
+  readme_workflow_status: ReadmeWorkflowStatus;
 };
 
 type VibeScaffoldUpdateOptions = {
@@ -475,7 +478,7 @@ async function upsertReadmeWorkflowSection(
   dryRun: boolean,
   result: InitScaffoldResult,
   previews?: VibeScaffoldDiffPreview[],
-): Promise<void> {
+): Promise<ReadmeWorkflowStatus> {
   const workflowBlock = buildReadmeWorkflowBlock();
   const readmeExists = await pathExists(readmePath);
 
@@ -485,7 +488,7 @@ async function upsertReadmeWorkflowSection(
     }
     pushChange(result, "created", readmePath);
     recordPreview(previews, readmePath, null, workflowBlock);
-    return;
+    return "created";
   }
 
   const current = await readFile(readmePath, "utf8");
@@ -493,6 +496,7 @@ async function upsertReadmeWorkflowSection(
   const end = findStandaloneMarkerIndex(current, README_WORKFLOW_END);
 
   let next = current;
+  let status: ReadmeWorkflowStatus = "updated";
   if (start >= 0 && end > start) {
     const endWithMarker = end + README_WORKFLOW_END.length;
     next = `${current.slice(0, start)}${workflowBlock}${current.slice(endWithMarker)}`;
@@ -500,6 +504,7 @@ async function upsertReadmeWorkflowSection(
     const separator = current.endsWith("\n") ? "\n" : "\n\n";
     next = `${current}${separator}${workflowBlock}`;
   } else {
+    status = "repaired";
     let repairedBase = current;
     if (start >= 0 && end < 0) {
       // Start marker without end marker: treat trailing region as corrupted managed block.
@@ -515,7 +520,7 @@ async function upsertReadmeWorkflowSection(
 
   if (next === current) {
     pushChange(result, "unchanged", readmePath);
-    return;
+    return "unchanged";
   }
 
   if (!dryRun) {
@@ -523,6 +528,7 @@ async function upsertReadmeWorkflowSection(
   }
   pushChange(result, "updated", readmePath);
   recordPreview(previews, readmePath, current, next);
+  return status;
 }
 
 async function upsertGitignoreEntries(
@@ -676,6 +682,7 @@ export async function applyVibeScaffoldUpdate(options: VibeScaffoldUpdateOptions
     created: [],
     updated: [],
     unchanged: [],
+    readme_workflow_status: "unchanged",
   };
 
   if (check.status === "not-initialized" || !check.updateAvailable) {
@@ -702,7 +709,12 @@ export async function applyVibeScaffoldUpdate(options: VibeScaffoldUpdateOptions
     result.previews,
   );
   await upsertAgentSnippet(path.join(cwd, "AGENTS.md"), dryRun, result, result.previews);
-  await upsertReadmeWorkflowSection(path.join(cwd, "README.md"), dryRun, result, result.previews);
+  result.readme_workflow_status = await upsertReadmeWorkflowSection(
+    path.join(cwd, "README.md"),
+    dryRun,
+    result,
+    result.previews,
+  );
   await upsertGitignoreEntries(path.join(cwd, ".gitignore"), dryRun, result, result.previews);
 
   result.applied = !dryRun;

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -501,6 +501,7 @@ async function upsertReadmeWorkflowSection(
     const endWithMarker = end + README_WORKFLOW_END.length;
     next = `${current.slice(0, start)}${workflowBlock}${current.slice(endWithMarker)}`;
   } else if (start < 0 && end < 0) {
+    status = "created";
     const separator = current.endsWith("\n") ? "\n" : "\n\n";
     next = `${current}${separator}${workflowBlock}`;
   } else {

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -278,7 +278,7 @@ describe.sequential("cli update flows", () => {
     expect(readFileSync(readmePath, "utf8")).toContain("<!-- vibe:workflow-docs:start -->");
   });
 
-  it("reports readme_workflow_status=updated in update --json when README block is inserted or refreshed", async () => {
+  it("reports readme_workflow_status=created in update --json when README block is inserted for the first time", async () => {
     const logs: string[] = [];
     const execaMock = vi.fn(async () => ({ stdout: "" }));
 
@@ -299,10 +299,51 @@ describe.sequential("cli update flows", () => {
     await program.parseAsync(["node", "vibe", "update", "--json"]);
     const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
 
-    expect(payload.readme_workflow_status).toBe("updated");
+    expect(payload.readme_workflow_status).toBe("created");
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("Manual text only.");
     expect(readme).toContain("<!-- vibe:workflow-docs:start -->");
+  });
+
+  it("reports readme_workflow_status=updated in update --json when managed README block is refreshed", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    const metadataPath = path.join(tempDir, ".vibe", "scaffold.json");
+    const readmePath = path.join(tempDir, "README.md");
+    unlinkSync(metadataPath);
+    writeFileSync(
+      readmePath,
+      [
+        "# Demo repo",
+        "",
+        "Manual intro.",
+        "",
+        "<!-- vibe:workflow-docs:start -->",
+        "stale managed block",
+        "<!-- vibe:workflow-docs:end -->",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    logs.length = 0;
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+    const readme = readFileSync(readmePath, "utf8");
+
+    expect(payload.readme_workflow_status).toBe("updated");
+    expect(readme).toContain("Manual intro.");
+    expect(readme).not.toContain("stale managed block");
+    expect(readme).toContain("flowchart LR");
   });
 
   it("reports readme_workflow_status=unchanged in update --json when scaffold is already up-to-date", async () => {
@@ -486,8 +527,9 @@ describe.sequential("cli update flows", () => {
     );
 
     logs.length = 0;
-    await program.parseAsync(["node", "vibe", "update"]);
-    expect(logs.some((line) => line.includes("scaffold update: DONE"))).toBe(true);
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+    expect(payload.readme_workflow_status).toBe("repaired");
 
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("Manual intro.");

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -252,6 +252,120 @@ describe.sequential("cli update flows", () => {
     expect(payload.status).toBe("not-initialized");
   });
 
+  it("reports readme_workflow_status=created in update --json when README is created", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    const metadataPath = path.join(tempDir, ".vibe", "scaffold.json");
+    const readmePath = path.join(tempDir, "README.md");
+    unlinkSync(metadataPath);
+    unlinkSync(readmePath);
+
+    logs.length = 0;
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+
+    expect(payload.kind).toBe("scaffold-update");
+    expect(payload.readme_workflow_status).toBe("created");
+    expect(readFileSync(readmePath, "utf8")).toContain("<!-- vibe:workflow-docs:start -->");
+  });
+
+  it("reports readme_workflow_status=updated in update --json when README block is inserted or refreshed", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    const metadataPath = path.join(tempDir, ".vibe", "scaffold.json");
+    const readmePath = path.join(tempDir, "README.md");
+    unlinkSync(metadataPath);
+    writeFileSync(readmePath, "# Demo repo\n\nManual text only.\n", "utf8");
+
+    logs.length = 0;
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+
+    expect(payload.readme_workflow_status).toBe("updated");
+    const readme = readFileSync(readmePath, "utf8");
+    expect(readme).toContain("Manual text only.");
+    expect(readme).toContain("<!-- vibe:workflow-docs:start -->");
+  });
+
+  it("reports readme_workflow_status=unchanged in update --json when scaffold is already up-to-date", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    logs.length = 0;
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+    const check = payload.check as Record<string, unknown>;
+
+    expect(payload.readme_workflow_status).toBe("unchanged");
+    expect(check.updateAvailable).toBe(false);
+  });
+
+  it("reports readme_workflow_status=repaired in update --json when workflow markers are malformed", async () => {
+    const logs: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--skip-tracker"]);
+
+    const metadataPath = path.join(tempDir, ".vibe", "scaffold.json");
+    const readmePath = path.join(tempDir, "README.md");
+    unlinkSync(metadataPath);
+    writeFileSync(
+      readmePath,
+      [
+        "# Demo repo",
+        "",
+        "Manual intro.",
+        "",
+        "<!-- vibe:workflow-docs:start -->",
+        "stale fragment",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    logs.length = 0;
+    await program.parseAsync(["node", "vibe", "update", "--json"]);
+    const payload = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+    const readme = readFileSync(readmePath, "utf8");
+
+    expect(payload.readme_workflow_status).toBe("repaired");
+    expect(readme).not.toContain("stale fragment");
+    expect((readme.match(/<!-- vibe:workflow-docs:start -->/g) ?? []).length).toBe(1);
+    expect((readme.match(/<!-- vibe:workflow-docs:end -->/g) ?? []).length).toBe(1);
+  });
+
   it("does not treat inline marker mentions as managed workflow boundaries", async () => {
     const logs: string[] = [];
     const execaMock = vi.fn(async () => ({ stdout: "" }));


### PR DESCRIPTION
## Summary
- Issue: #97 feat(metrics): expose README workflow scaffold adoption signal in JSON output
- Branch: `codex/issue-97-readme-workflow-status`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/97

## Architecture decisions
- Scope this PR to issue #97 (`feat(metrics): expose README workflow scaffold adoption signal in JSON output`) on branch `codex/issue-97-readme-workflow-status` in `pr-open` mode.
- Derived from changed files (8): profile=`code+tests+docs`, modules=[cli, docs, tests], sample=`.vibe/reviews/97/growth.md`, `.vibe/reviews/97/implementation.md`, `.vibe/reviews/97/ops.md`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Generate reviewer context from issue metadata (`feat(metrics): expose README workflow scaffold adoption signal in JSON output`; themes=pr, docs; labels=enhancement, module:cli, module:docs) instead of reusing a boilerplate rationale block.
- Mixed code+tests changes need a rationale that links behavior changes to the test edits in the same PR, which a generic template cannot express.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Keep one fixed rationale bullet set for every PR: rejected because it produces low-signal descriptions across unrelated changes.
- Split code and tests into unrelated narratives: rejected because reviewers need one cohesive explanation for behavior plus verification.
- Claim evidence not present in the signals (sample `.vibe/reviews/97/growth.md`, `.vibe/reviews/97/implementation.md`, `.vibe/reviews/97/ops.md`): rejected to keep rationale deterministic and auditable.

Fixes #97