### PR TITLE
#101 bug(pr): rationale misclassifies dependency/security PRs as docs-only

### DIFF
--- a/.vibe/reviews/101/growth.md
+++ b/.vibe/reviews/101/growth.md
@@ -15,3 +15,15 @@ No growth blockers; this directly improves communication quality in shared PR na
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:29:48.499Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No growth blockers detected; clearer rationale text for dependency/security PRs improves reviewer trust and shareability of PR context.
+
+### Findings
+- none

--- a/.vibe/reviews/101/growth.md
+++ b/.vibe/reviews/101/growth.md
@@ -1,0 +1,17 @@
+## Run 2026-03-02T17:27:37Z
+Growth/learning opportunities:
+- More accurate architecture rationale improves reviewer trust and perceived product quality when sharing PRs externally.
+- Explicit dependency/security intent in PR body lowers cognitive overhead for collaborators validating vulnerability remediation.
+- Follow-up opportunity: include advisory IDs in rationale signals when issue body contains CVE/GHSA markers.
+
+## Run 2026-03-02T17:27:37Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No growth blockers; this directly improves communication quality in shared PR narratives.
+
+### Findings
+- none

--- a/.vibe/reviews/101/implementation.md
+++ b/.vibe/reviews/101/implementation.md
@@ -20,3 +20,15 @@ No implementation defects identified; fix directly addresses the observed miscla
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:29:48.496Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects found; the fix correctly filters generated `.vibe` artifacts from rationale signals and introduces dependency-aware profiling for dependency-only diffs.
+
+### Findings
+- none

--- a/.vibe/reviews/101/implementation.md
+++ b/.vibe/reviews/101/implementation.md
@@ -1,0 +1,22 @@
+## Run 2026-03-02T17:27:37Z
+- Scope: issue #101 bugfix for PR rationale architecture text being template/misaligned on dependency-security PRs.
+- Changes:
+  - Filtered generated `.vibe` review/postflight artifacts from rationale changed-file signals.
+  - Added dependency-file detection (`package.json`, lockfiles) and `deps-only` change profile.
+  - Added dependency-specific rationale lines for architecture/why/alternatives sections.
+  - Added regression test covering dependency patch + `.vibe` artifact noise.
+- Files:
+  - `src/core/pr-rationale.ts`
+  - `tests/pr-rationale.test.ts`
+
+## Run 2026-03-02T17:27:37Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects identified; fix directly addresses the observed misclassification path.
+
+### Findings
+- none

--- a/.vibe/reviews/101/ops.md
+++ b/.vibe/reviews/101/ops.md
@@ -17,3 +17,15 @@ Operational risk is low; patch is bounded to rationale generation logic and vali
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:29:48.499Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No operational issues found; change is localized to rationale generation logic and tests, with no CI/package workflow regressions observed.
+
+### Findings
+- none

--- a/.vibe/reviews/101/ops.md
+++ b/.vibe/reviews/101/ops.md
@@ -1,0 +1,19 @@
+## Run 2026-03-02T17:27:37Z
+Ops/release checks:
+- Deterministic verification completed with:
+  - `pnpm test`
+  - `pnpm build`
+- No dependency graph, packaging, or CI workflow configuration changes were made.
+- Output contract change is internal to rationale text/debug classification and covered by tests.
+
+## Run 2026-03-02T17:27:37Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Operational risk is low; patch is bounded to rationale generation logic and validated with full suite/build.
+
+### Findings
+- none

--- a/.vibe/reviews/101/quality.md
+++ b/.vibe/reviews/101/quality.md
@@ -1,0 +1,28 @@
+## Run 2026-03-02T17:27:37Z
+What I tested:
+- Added coverage for dependency patch rationale with generated `.vibe` artifact noise in changed-file input.
+- Verified profile/debug outputs:
+  - profile `deps-only`
+  - filtered changed file sample/count excludes `.vibe/reviews/*` and `.vibe/artifacts/postflight.json`
+  - rationale text is dependency-specific (not docs-only template).
+- Ran full test suite and build.
+
+Commands:
+- `pnpm test -- tests/pr-rationale.test.ts`
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- Live GitHub PR body generation end-to-end in remote environment (unit-level generation paths covered).
+
+## Run 2026-03-02T17:27:37Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Quality coverage is sufficient for the misclassification regression and deterministic output behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/101/quality.md
+++ b/.vibe/reviews/101/quality.md
@@ -26,3 +26,15 @@ Quality coverage is sufficient for the misclassification regression and determin
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:29:48.498Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No quality findings; regression coverage was added for `.vibe` noise filtering and `deps-only` classification, and validation commands are passing.
+
+### Findings
+- none

--- a/.vibe/reviews/101/security.md
+++ b/.vibe/reviews/101/security.md
@@ -18,3 +18,15 @@ No new security defects found; this improves security communication accuracy for
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:29:48.498Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No new security risks introduced; the change improves security communication fidelity for dependency-remediation PRs without expanding execution or privilege surfaces.
+
+### Findings
+- none

--- a/.vibe/reviews/101/security.md
+++ b/.vibe/reviews/101/security.md
@@ -1,0 +1,20 @@
+## Run 2026-03-02T17:27:37Z
+Threat model quick scan:
+This change modifies PR-body rationale generation logic only. Primary risks are misleading reviewer context that could hide real dependency/security intent, and regression in deterministic rationale output that affects auditability.
+
+Checks and mitigations:
+- Dependency/security patches now emit explicit dependency-oriented rationale lines, reducing misleading docs-only narratives.
+- Noise filtering is scoped to known generated `.vibe` artifacts, minimizing risk of dropping relevant source files.
+- No new command execution, secrets handling, or permission boundary changes were introduced.
+
+## Run 2026-03-02T17:27:37Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No new security defects found; this improves security communication accuracy for dependency patch PRs.
+
+### Findings
+- none

--- a/.vibe/reviews/101/ux.md
+++ b/.vibe/reviews/101/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T17:29:48.499Z
+- run_id: issue-101-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No UI surfaces were changed. Under standard assumptions (8pt spacing grid, 16px body type, 44px minimum target size), there are no applicable design-system or accessibility findings.
+
+### Findings
+- none

--- a/src/core/pr-rationale.ts
+++ b/src/core/pr-rationale.ts
@@ -77,9 +77,13 @@ const RATIONALE_AUTOCLOSE_FOOTER_REGEX = /^\s*(?:fix(?:e[sd])?|close[sd]?|resolv
 const TODO_PLACEHOLDER_LINE_REGEX = /(?:^|\r?\n)\s*(?:[-*]\s+)?TODO(?:\s*:|\b)/i;
 const DOC_FILE_REGEX = /(?:^|\/)(?:README|CHANGELOG|SECURITY|CONTRIBUTING)\.md$/i;
 const MARKDOWN_FILE_REGEX = /\.md$/i;
+const DEPENDENCY_FILE_REGEX =
+  /(?:^|\/)(?:package\.json|package-lock\.json|pnpm-lock\.yaml|yarn\.lock|npm-shrinkwrap\.json|bun\.lockb?)$/i;
+const RATIONALE_SIGNAL_NOISE_FILE_REGEX = /^\.vibe\/(?:reviews\/.+\.md|artifacts\/postflight\.json)$/i;
 
 export type ChangeProfile =
   | "unknown"
+  | "deps-only"
   | "docs-only"
   | "tests-only"
   | "code-only"
@@ -130,6 +134,7 @@ type RationaleFacts = {
   hasDocs: boolean;
   hasTests: boolean;
   hasCode: boolean;
+  hasDeps: boolean;
   profile: ChangeProfile;
   sampleFiles: string[];
   issueThemes: string[];
@@ -199,8 +204,17 @@ function isCodeFile(file: string): boolean {
   return file.startsWith("src/") || file.startsWith("apps/") || file.startsWith("packages/");
 }
 
+function isDependencyFile(file: string): boolean {
+  return DEPENDENCY_FILE_REGEX.test(file);
+}
+
+function isRationaleSignalNoiseFile(file: string): boolean {
+  return RATIONALE_SIGNAL_NOISE_FILE_REGEX.test(file);
+}
+
 function toModuleFromFile(file: string): string | null {
   const lower = file.toLowerCase();
+  if (isDependencyFile(file)) return "deps";
   if (isDocFile(file)) return "docs";
   if (isTestFile(file)) return "tests";
   if (lower.startsWith("src/ui/") || lower.startsWith("ui/") || lower.startsWith("app/")) return "ui";
@@ -219,9 +233,16 @@ function toModuleFromFile(file: string): string | null {
   return null;
 }
 
-function classifyProfile(params: { hasDocs: boolean; hasTests: boolean; hasCode: boolean; fileCount: number }): ChangeProfile {
+function classifyProfile(params: {
+  hasDocs: boolean;
+  hasTests: boolean;
+  hasCode: boolean;
+  hasDeps: boolean;
+  fileCount: number;
+}): ChangeProfile {
   if (params.fileCount === 0) return "unknown";
-  if (params.hasDocs && !params.hasTests && !params.hasCode) return "docs-only";
+  if (params.hasDeps && !params.hasDocs && !params.hasTests && !params.hasCode) return "deps-only";
+  if (params.hasDocs && !params.hasTests && !params.hasCode && !params.hasDeps) return "docs-only";
   if (!params.hasDocs && params.hasTests && !params.hasCode) return "tests-only";
   if (!params.hasDocs && !params.hasTests && params.hasCode) return "code-only";
   if (!params.hasDocs && params.hasTests && params.hasCode) return "code+tests";
@@ -301,10 +322,11 @@ function formatSampleFiles(files: readonly string[], maxItems = 3): string {
 
 function buildFacts(context: RationaleContext): RationaleFacts {
   const labels = normalizeList(context.signals?.issueLabels);
-  const changedFiles = normalizePaths(context.signals?.changedFiles);
+  const changedFiles = normalizePaths(context.signals?.changedFiles).filter((file) => !isRationaleSignalNoiseFile(file));
   const hasDocs = changedFiles.some((file) => isDocFile(file));
   const hasTests = changedFiles.some((file) => isTestFile(file));
   const hasCode = changedFiles.some((file) => isCodeFile(file));
+  const hasDeps = changedFiles.some((file) => isDependencyFile(file));
   const labelModules = normalizeList(labels.map((label) => toModuleFromLabel(label) ?? "").filter(Boolean));
   const fileModules = normalizeList(changedFiles.map((file) => toModuleFromFile(file) ?? "").filter(Boolean));
   const modules = normalizeList([...labelModules, ...fileModules]);
@@ -320,7 +342,8 @@ function buildFacts(context: RationaleContext): RationaleFacts {
     hasDocs,
     hasTests,
     hasCode,
-    profile: classifyProfile({ hasDocs, hasTests, hasCode, fileCount: changedFiles.length }),
+    hasDeps,
+    profile: classifyProfile({ hasDocs, hasTests, hasCode, hasDeps, fileCount: changedFiles.length }),
     sampleFiles: changedFiles.slice(0, 3),
     issueThemes: detectIssueThemes(context, labels),
     validationSignals,
@@ -380,6 +403,10 @@ function buildArchitectureLines(context: RationaleContext, facts: RationaleFacts
 
   if (facts.profile === "docs-only") {
     lines.push("- Keep runtime/CLI behavior claims out of the rationale; this diff reads as documentation-only.");
+  } else if (facts.profile === "deps-only") {
+    lines.push(
+      "- Keep this rationale dependency-focused: explain advisory/version-risk reduction intent instead of inventing feature or runtime behavior changes.",
+    );
   } else if (facts.profile === "tests-only") {
     lines.push("- Frame the PR as verification-focused: explain which behavior is being locked down without implying implementation edits.");
   } else if (facts.hasCode && facts.hasTests) {
@@ -402,6 +429,10 @@ function buildWhyLines(context: RationaleContext, facts: RationaleFacts): string
 
   if (facts.profile === "docs-only") {
     lines.push("- A docs-only diff should justify wording/contract clarifications, not claim code-path risk changes that are absent from the touched files.");
+  } else if (facts.profile === "deps-only") {
+    lines.push(
+      "- A dependency-only diff should explain version/advisory intent (for example vulnerability remediation) rather than implying direct feature implementation.",
+    );
   } else if (facts.profile === "tests-only") {
     lines.push("- A tests-only diff should explain the regression or edge case being pinned so review effort stays focused on intent and coverage quality.");
   } else if (facts.hasCode && facts.hasTests) {
@@ -441,6 +472,8 @@ function buildAlternativesLines(context: RationaleContext, facts: RationaleFacts
 
   if (facts.profile === "docs-only") {
     lines.push("- Describe docs-only edits as runtime refactors: rejected because no code/test paths appear in the touched-file signal.");
+  } else if (facts.profile === "deps-only") {
+    lines.push("- Describe dependency-only updates as feature delivery work: rejected because the diff signal is package manifest/lockfile maintenance.");
   } else if (facts.profile === "tests-only") {
     lines.push("- Present test-only work as a feature implementation: rejected because the diff signal shows verification changes without runtime edits.");
   } else if (facts.hasCode && facts.hasTests) {

--- a/tests/pr-rationale.test.ts
+++ b/tests/pr-rationale.test.ts
@@ -210,6 +210,38 @@ describe("pr rationale helpers", () => {
     );
   });
 
+  it("filters .vibe review artifacts and classifies dependency patches as deps-only", () => {
+    const context: RationaleContext = {
+      issueId: 99,
+      issueTitle: "security(deps): patch rollup CVE-2026-27606",
+      branch: "codex/issue-99-rollup-cve-2026-27606",
+      mode: "pr-open",
+      signals: {
+        issueLabels: ["bug", "module:cli"],
+        changedFiles: [
+          ".vibe/reviews/99/implementation.md",
+          ".vibe/reviews/99/security.md",
+          ".vibe/artifacts/postflight.json",
+          "package.json",
+          "pnpm-lock.yaml",
+        ],
+      },
+    };
+
+    const sections = buildRationaleSections(context);
+    const debug = buildRationaleSignalDebug(context);
+
+    expect(sections.architecture.join("\n")).toContain("profile=`deps-only`");
+    expect(sections.architecture.join("\n")).not.toContain("documentation-only");
+    expect(sections.why.join("\n")).toContain("dependency-only diff");
+    expect(sections.alternatives.join("\n")).toContain("dependency-only updates");
+    expect(debug.profile).toBe("deps-only");
+    expect(debug.modules).toEqual(expect.arrayContaining(["cli", "deps"]));
+    expect(debug.changed_files_count).toBe(2);
+    expect(debug.changed_files_sample).toEqual(["package.json", "pnpm-lock.yaml"]);
+    expect(debug.fallback_reasons).toContainEqual(expect.objectContaining({ code: "validation-signals-unavailable" }));
+  });
+
   it("preserves user-written text outside placeholder sections during autofill", () => {
     const body = [
       "## Summary",


### PR DESCRIPTION
## Summary
- Issue: #101 bug(pr): rationale misclassifies dependency/security PRs as docs-only
- Branch: `codex/issue-101-pr-rationale-deps-signal`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/101

## Architecture decisions
- Scope this PR to issue #101 (`bug(pr): rationale misclassifies dependency/security PRs as docs-only`) on branch `codex/issue-101-pr-rationale-deps-signal` in `pr-open` mode.
- Derived from changed files (2): profile=`code+tests`, modules=[cli, pr, tests], sample=`src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Generate reviewer context from issue metadata (`bug(pr): rationale misclassifies dependency/security PRs as docs-only`; themes=pr, review, tracker, docs, security, postflight; labels=bug, module:cli, status:backlog) instead of reusing a boilerplate rationale block.
- Mixed code+tests changes need a rationale that links behavior changes to the test edits in the same PR, which a generic template cannot express.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Keep one fixed rationale bullet set for every PR: rejected because it produces low-signal descriptions across unrelated changes.
- Split code and tests into unrelated narratives: rejected because reviewers need one cohesive explanation for behavior plus verification.
- Claim evidence not present in the signals (sample `src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`): rejected to keep rationale deterministic and auditable.

Fixes #101