### PR TITLE
#103 docs(onboarding): add quickstart + share playbook for phased rollout

### DIFF
--- a/.vibe/reviews/103/growth.md
+++ b/.vibe/reviews/103/growth.md
@@ -1,0 +1,25 @@
+# Growth Pass
+
+## Review Focus
+- Funnel stage(s) touched:
+- Instrumentation/experiment impact:
+
+## Checklist
+- [ ] Activation/retention/conversion opportunities reviewed
+- [ ] Measurement gaps and hypotheses captured
+- [ ] Next growth actions are concrete and testable
+
+## Notes
+- 
+
+## Run 2026-03-02T17:47:26.572Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+skipped by policy
+
+### Findings
+- none

--- a/.vibe/reviews/103/implementation.md
+++ b/.vibe/reviews/103/implementation.md
@@ -1,0 +1,25 @@
+# Implementation Pass
+
+## Scope
+- Issue:
+- Goal:
+
+## Checklist
+- [ ] Diff kept focused to issue scope
+- [ ] Behavior changes documented
+- [ ] Follow-up work listed (if any)
+
+## Notes
+- 
+
+## Run 2026-03-02T17:47:26.569Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects found in scope; docs updates are coherent with current CLI workflow and sharing intent.
+
+### Findings
+- none

--- a/.vibe/reviews/103/ops.md
+++ b/.vibe/reviews/103/ops.md
@@ -1,0 +1,25 @@
+# Ops Pass
+
+## Release Readiness
+- Commands run:
+- Operational risks:
+
+## Checklist
+- [ ] Build/test reproducibility validated
+- [ ] Rollback strategy noted
+- [ ] CI/deploy impact reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T17:47:26.573Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No operational issues identified; change is docs-only and does not modify CI/package/runtime behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/103/quality.md
+++ b/.vibe/reviews/103/quality.md
@@ -1,0 +1,24 @@
+## Run 2026-03-02T17:45:47Z
+What I tested:
+- Added a short onboarding section in README (`Quickstart (5 min)`) with first-run command sequence.
+- Added `SHARE.md` with phased rollout checklist (pilot/beta/social), copy templates, and setup friction notes.
+- Verified docs consistency against existing README command references.
+
+Commands:
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- External user comprehension/usability in live beta environments (requires real user feedback loop).
+
+## Run 2026-03-02T17:45:47Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Docs scope is consistent and sufficiently verified for this onboarding/share kit update.
+
+### Findings
+- none

--- a/.vibe/reviews/103/quality.md
+++ b/.vibe/reviews/103/quality.md
@@ -22,3 +22,15 @@ Docs scope is consistent and sufficiently verified for this onboarding/share kit
 
 ### Findings
 - none
+
+## Run 2026-03-02T17:47:26.571Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No quality findings. The quickstart and sharing playbook are aligned with existing commands and fallback behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/103/security.md
+++ b/.vibe/reviews/103/security.md
@@ -1,0 +1,25 @@
+# Security Pass
+
+## Threat Scan
+- Risks considered:
+- Mitigations applied:
+
+## Checklist
+- [ ] Input validation paths reviewed
+- [ ] Authorization/data exposure reviewed
+- [ ] Error handling avoids sensitive leakage
+
+## Notes
+- 
+
+## Run 2026-03-02T17:47:26.570Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No security-impacting changes detected; this diff is documentation-only and does not alter execution paths or trust boundaries.
+
+### Findings
+- none

--- a/.vibe/reviews/103/ux.md
+++ b/.vibe/reviews/103/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T17:47:26.572Z
+- run_id: issue-103-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+skipped by policy
+
+### Findings
+- none

--- a/README.md
+++ b/README.md
@@ -10,6 +10,33 @@ This project has two usage modes:
 
 Do not rely only on the global bin path. Always keep the canonical path available.
 
+## Quickstart (5 min)
+
+Fastest path to first success in another repo:
+
+```bash
+# in vibe-backlog repo
+pnpm install
+pnpm build
+pnpm link --global
+hash -r
+
+# in your target repo
+cd /path/to/another-repo
+vibe init --dry-run
+vibe init
+vibe preflight
+vibe postflight --apply --dry-run
+```
+
+If `gh` is unavailable in the target repo, run:
+
+```bash
+vibe init --skip-tracker
+```
+
+For phased sharing (pilot -> beta -> social) and copy/paste launch messages, see [SHARE.md](./SHARE.md).
+
 ## 0) Requirements
 
 ```bash

--- a/SHARE.md
+++ b/SHARE.md
@@ -1,0 +1,126 @@
+# Share Playbook
+
+Operational guide to share `vibe-backlog` in three phases:
+
+1. personal pilot
+2. private beta with friends
+3. public social launch
+
+## Phase 1: Personal Pilot (Your Repo)
+
+Goal: verify the full loop in a real repo you control.
+
+Checklist:
+
+- Install and build locally from source.
+- Link global binary (`pnpm link --global`) or use canonical `node dist/cli.cjs`.
+- Run `vibe init --dry-run` then `vibe init` in target repo.
+- Run `vibe preflight`.
+- Create/update `.vibe/artifacts/postflight.json` with real `issue_id`.
+- Run `vibe postflight` then `vibe postflight --apply --dry-run`.
+- Confirm generated files are clear (`AGENTS.md`, `.vibe/contract.yml`, README managed block).
+
+Exit criteria:
+
+- You can complete preflight -> work -> postflight without manual workarounds.
+- Outputs are understandable to you without reading source code.
+
+## Phase 2: Private Beta (Friends)
+
+Goal: validate onboarding clarity and identify friction points.
+
+Checklist:
+
+- Send the short invite message below.
+- Share the "beta quickstart" command block.
+- Ask each beta tester for:
+  - first blocker command
+  - most useful command
+  - one thing that was unclear
+- Track feedback in GitHub issues (one issue per topic).
+
+Exit criteria:
+
+- At least 3 testers complete quickstart.
+- No critical blocker remains in setup flow.
+
+## Phase 3: Public Social Launch
+
+Goal: collect broader inbound interest once onboarding is stable.
+
+Checklist:
+
+- Ensure no open P0/P1 issues affecting CLI basics.
+- Keep a short CTA:
+  - "comment beta" / "DM me"
+- Be explicit that this is CLI-first and UI is roadmap.
+- Point to README + quickstart section.
+
+Exit criteria:
+
+- People can self-serve first run from docs.
+- You can triage incoming feedback within 24-48h.
+
+## Beta Quickstart (Send This)
+
+```bash
+# 1) in vibe-backlog repo
+pnpm install
+pnpm build
+pnpm link --global
+hash -r
+
+# 2) in your target repo
+cd /path/to/your-repo
+vibe init --dry-run
+vibe init
+vibe preflight
+vibe postflight --apply --dry-run
+```
+
+Fallback without GitHub CLI:
+
+```bash
+vibe init --skip-tracker
+```
+
+## Message Templates
+
+### Beta DM (short)
+
+```text
+Estoy probando una CLI para flujo issue-first + postflight en repos con GitHub.
+Si te copa, te paso un quickstart de 5 minutos para probarla en un repo de prueba.
+Me sirve feedback de fricción de instalación y claridad de comandos.
+```
+
+### Beta DM (expanded)
+
+```text
+Estoy abriendo beta chica de vibe-backlog.
+Es una CLI para trabajar issue-first con guardrails de git/tracker y cierre con postflight.
+¿Te sumás a probarla 10-15 minutos en un repo personal?
+Si querés, te paso quickstart + checklist y me dejás feedback de onboarding.
+```
+
+### Social Post (X/LinkedIn)
+
+```text
+Estoy abriendo beta de vibe-backlog: una CLI para operar proyectos con issue-first + postflight, guardrails de git/tracker y review flow.
+Es CLI-first (UI queda en roadmap).
+Si querés probarla en tu repo, comentá “beta” y te paso quickstart.
+```
+
+## Common Setup Friction
+
+- `vibe: command not found`
+  - rerun `pnpm link --global` and `hash -r`
+- `gh` not available
+  - use `vibe init --skip-tracker`
+- confused between global and canonical execution
+  - run canonical path from this repo: `node dist/cli.cjs <command>`
+
+## Canonical References
+
+- Main docs and command references: [README.md](./README.md)
+- Agent workflow contract: [AGENTS.md](./AGENTS.md)


### PR DESCRIPTION
## Summary
- Issue: #103 docs(onboarding): add quickstart + share playbook for phased rollout
- Branch: `codex/issue-103-share-quickstart-playbook`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/103

## Architecture decisions
- Scope this PR to issue #103 (`docs(onboarding): add quickstart + share playbook for phased rollout`) on branch `codex/issue-103-share-quickstart-playbook` in `pr-open` mode.
- Derived from changed files (2): profile=`docs-only`, modules=[docs], sample=`README.md`, `SHARE.md`.
- Keep runtime/CLI behavior claims out of the rationale; this diff reads as documentation-only.

## Why these decisions were made
- Generate reviewer context from issue metadata (`docs(onboarding): add quickstart + share playbook for phased rollout`; themes=tracker, docs; labels=enhancement, module:docs, status:backlog) instead of reusing a boilerplate rationale block.
- A docs-only diff should justify wording/contract clarifications, not claim code-path risk changes that are absent from the touched files.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Keep one fixed rationale bullet set for every PR: rejected because it produces low-signal descriptions across unrelated changes.
- Describe docs-only edits as runtime refactors: rejected because no code/test paths appear in the touched-file signal.
- Claim evidence not present in the signals (sample `README.md`, `SHARE.md`): rejected to keep rationale deterministic and auditable.

Fixes #103