### PR TITLE
#16 feat(ui): dashboard shell for local project cockpit

### DIFF
--- a/.vibe/reviews/16/growth.md
+++ b/.vibe/reviews/16/growth.md
@@ -4,3 +4,16 @@ Growth pass:
 - Next measurable opportunities:
   - Add event counters for `project_selected`, `status_loaded`, and `no_turn_detected` to quantify onboarding friction.
   - Add CTA nudges when turn context is missing (e.g., inline `vibe turn start --issue <n>` copy button) to improve first successful workflow completion.
+
+## Run 2026-03-02T19:48:15.950Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 2
+- autofix_applied: no
+
+### Summary
+Two product-growth opportunities are evident and should be tracked as follow-up issues.
+
+### Findings
+- [P3] No instrumentation for selector usage or status load failures (src/ui/cockpit.ts:368)
+- [P3] Missing-turn empty state lacks a direct activation CTA (src/ui/cockpit.ts:523)

--- a/.vibe/reviews/16/growth.md
+++ b/.vibe/reviews/16/growth.md
@@ -1,0 +1,6 @@
+## Run 2026-03-02T19:43:57Z
+Growth pass:
+- This shell increases activation by reducing setup ambiguity: users can immediately see workspace scope, available repos, and whether a repo has active turn linkage.
+- Next measurable opportunities:
+  - Add event counters for `project_selected`, `status_loaded`, and `no_turn_detected` to quantify onboarding friction.
+  - Add CTA nudges when turn context is missing (e.g., inline `vibe turn start --issue <n>` copy button) to improve first successful workflow completion.

--- a/.vibe/reviews/16/growth.md
+++ b/.vibe/reviews/16/growth.md
@@ -17,3 +17,15 @@ Two product-growth opportunities are evident and should be tracked as follow-up 
 ### Findings
 - [P3] No instrumentation for selector usage or status load failures (src/ui/cockpit.ts:368)
 - [P3] Missing-turn empty state lacks a direct activation CTA (src/ui/cockpit.ts:523)
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Growth notes implemented: lightweight telemetry hooks (`project_selected`, `status_loaded`, `status_load_failed`) and clearer missing-turn activation CTA.
+
+### Findings
+- none

--- a/.vibe/reviews/16/growth.md
+++ b/.vibe/reviews/16/growth.md
@@ -29,3 +29,15 @@ Growth notes implemented: lightweight telemetry hooks (`project_selected`, `stat
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.522Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Telemetry hooks for selection/load/failure and activation CTA were added, covering the primary growth gaps identified in the prior pass; no additional growth findings in this diff.
+
+### Findings
+- none

--- a/.vibe/reviews/16/implementation.md
+++ b/.vibe/reviews/16/implementation.md
@@ -1,0 +1,9 @@
+## Run 2026-03-02T19:43:57Z
+- Scope: issue #16 (`feat(ui): dashboard shell for local project cockpit`).
+- Implemented a new local cockpit module at `src/ui/cockpit.ts` with:
+  - Workspace project discovery (`.git` marker, root + first-level repos).
+  - Route layer for `/`, `/api/projects`, `/api/project-status`, `/healthz`.
+  - Responsive dashboard shell (header/sidebar/main), project selector, workspace path visibility, and baseline branch/turn/issue status cards.
+  - `startCockpitServer` / `stopCockpitServer` lifecycle for CLI usage.
+- Wired CLI command `ui serve` in `src/cli-program.ts` with host/port/workspace options and graceful SIGINT/SIGTERM shutdown.
+- Added docs mention for `ui serve` in README canonical command list and command summary.

--- a/.vibe/reviews/16/implementation.md
+++ b/.vibe/reviews/16/implementation.md
@@ -31,3 +31,15 @@ Applied follow-up hardening for review findings (remote-bind guard/remediation, 
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.520Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Reviewed the updated CLI/UI diff (remote-bind guardrails, telemetry hooks, CTA state handling, and test additions); no implementation defects found.
+
+### Findings
+- none

--- a/.vibe/reviews/16/implementation.md
+++ b/.vibe/reviews/16/implementation.md
@@ -19,3 +19,15 @@ UI shell, API route structure, and CLI wiring are coherent for the MVP scope; no
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Applied follow-up hardening for review findings (remote-bind guard/remediation, UI accessibility tweaks, activation CTA, telemetry hooks, and additional tests). No implementation defects remain in the current diff.
+
+### Findings
+- none

--- a/.vibe/reviews/16/implementation.md
+++ b/.vibe/reviews/16/implementation.md
@@ -7,3 +7,15 @@
   - `startCockpitServer` / `stopCockpitServer` lifecycle for CLI usage.
 - Wired CLI command `ui serve` in `src/cli-program.ts` with host/port/workspace options and graceful SIGINT/SIGTERM shutdown.
 - Added docs mention for `ui serve` in README canonical command list and command summary.
+
+## Run 2026-03-02T19:48:15.946Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+UI shell, API route structure, and CLI wiring are coherent for the MVP scope; no direct functional defects were found in the reviewed diff.
+
+### Findings
+- none

--- a/.vibe/reviews/16/ops.md
+++ b/.vibe/reviews/16/ops.md
@@ -17,3 +17,15 @@ Operational behavior is mostly safe; one DX/reliability hardening item is recomm
 
 ### Findings
 - [P2] Startup failure path lacks actionable remediation for common bind errors (src/cli-program.ts:2010)
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Ops finding addressed by adding actionable bind-failure remediation guidance for `EADDRINUSE` and `EACCES/EPERM` startup errors.
+
+### Findings
+- none

--- a/.vibe/reviews/16/ops.md
+++ b/.vibe/reviews/16/ops.md
@@ -29,3 +29,15 @@ Ops finding addressed by adding actionable bind-failure remediation guidance for
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.522Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Startup failure handling now provides actionable operator remediation for common bind errors, and runtime guardrails are clearer; no ops findings remain.
+
+### Findings
+- none

--- a/.vibe/reviews/16/ops.md
+++ b/.vibe/reviews/16/ops.md
@@ -5,3 +5,15 @@ Ops/release pass:
   - `pnpm test`
   - `pnpm build`
 - CI/supply-chain impact is minimal for this slice because assets are inline and packaged through existing `tsup` pipeline.
+
+## Run 2026-03-02T19:48:15.950Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+Operational behavior is mostly safe; one DX/reliability hardening item is recommended.
+
+### Findings
+- [P2] Startup failure path lacks actionable remediation for common bind errors (src/cli-program.ts:2010)

--- a/.vibe/reviews/16/ops.md
+++ b/.vibe/reviews/16/ops.md
@@ -1,0 +1,7 @@
+## Run 2026-03-02T19:43:57Z
+Ops/release pass:
+- No new dependencies were added; implementation stays within existing Node + execa footprint.
+- Build and test remained deterministic under repo-local commands:
+  - `pnpm test`
+  - `pnpm build`
+- CI/supply-chain impact is minimal for this slice because assets are inline and packaged through existing `tsup` pipeline.

--- a/.vibe/reviews/16/quality.md
+++ b/.vibe/reviews/16/quality.md
@@ -12,3 +12,16 @@ Commands:
 
 Untested:
 - Manual browser interaction of `ui serve` runtime (selector switching and visual polish) remains for interactive QA.
+
+## Run 2026-03-02T19:48:15.949Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 2
+- autofix_applied: no
+
+### Summary
+Core coverage exists, but two behavior-critical test gaps remain for runtime robustness.
+
+### Findings
+- [P2] No lifecycle test covers real `ui serve` boot/shutdown path (tests/ui-cockpit.test.ts:62)
+- [P3] Missing tests for malformed turn context fallback behavior (src/ui/cockpit.ts:454)

--- a/.vibe/reviews/16/quality.md
+++ b/.vibe/reviews/16/quality.md
@@ -25,3 +25,15 @@ Core coverage exists, but two behavior-critical test gaps remain for runtime rob
 ### Findings
 - [P2] No lifecycle test covers real `ui serve` boot/shutdown path (tests/ui-cockpit.test.ts:62)
 - [P3] Missing tests for malformed turn context fallback behavior (src/ui/cockpit.ts:454)
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Quality gaps addressed with additional tests for malformed turn fallback and `ui serve` lifecycle/host-guard behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/16/quality.md
+++ b/.vibe/reviews/16/quality.md
@@ -1,0 +1,14 @@
+## Run 2026-03-02T19:43:57Z
+What I tested:
+- Added route/render smoke coverage in `tests/ui-cockpit.test.ts` for:
+  - Dashboard HTML shell rendering (`/`).
+  - Projects snapshot route (`/api/projects`).
+  - Project status route (`/api/project-status`) and unknown-project `404` handling.
+- Added CLI validation coverage in `tests/cli-ui.test.ts` for invalid `--port` fast-fail behavior.
+
+Commands:
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- Manual browser interaction of `ui serve` runtime (selector switching and visual polish) remains for interactive QA.

--- a/.vibe/reviews/16/quality.md
+++ b/.vibe/reviews/16/quality.md
@@ -37,3 +37,15 @@ Quality gaps addressed with additional tests for malformed turn fallback and `ui
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.521Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Coverage now includes malformed turn-context behavior and ui-serve lifecycle/host-guard command paths; no quality findings remain for this MVP slice.
+
+### Findings
+- none

--- a/.vibe/reviews/16/security.md
+++ b/.vibe/reviews/16/security.md
@@ -20,3 +20,15 @@ One security-relevant hardening gap was found around optional non-loopback expos
 
 ### Findings
 - [P2] Remote host binding can expose local repo metadata without explicit warning or guard (src/cli-program.ts:1985)
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Security finding addressed by requiring explicit `--allow-remote` for non-loopback binds and adding clear operator warnings/remediation output.
+
+### Findings
+- none

--- a/.vibe/reviews/16/security.md
+++ b/.vibe/reviews/16/security.md
@@ -32,3 +32,15 @@ Security finding addressed by requiring explicit `--allow-remote` for non-loopba
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.521Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Non-loopback exposure is now explicitly gated behind `--allow-remote`, with safer defaults and remediation messaging; no remaining security findings in this scope.
+
+### Findings
+- none

--- a/.vibe/reviews/16/security.md
+++ b/.vibe/reviews/16/security.md
@@ -8,3 +8,15 @@ Checks and mitigations:
 - HTML content is escaped (`safeText`) and boot JSON escapes `<` to reduce script injection risk.
 - Turn context parse failures are handled explicitly and returned as non-crashing status cards.
 - No credentials, tokens, or remote network calls are introduced by this UI slice.
+
+## Run 2026-03-02T19:48:15.948Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+One security-relevant hardening gap was found around optional non-loopback exposure.
+
+### Findings
+- [P2] Remote host binding can expose local repo metadata without explicit warning or guard (src/cli-program.ts:1985)

--- a/.vibe/reviews/16/security.md
+++ b/.vibe/reviews/16/security.md
@@ -1,0 +1,10 @@
+## Run 2026-03-02T19:43:57Z
+Threat model quick scan:
+The new surface is a local HTTP UI endpoint that reads project metadata from local filesystem and git state. Main risks are path traversal, accidental data disclosure in HTML/JSON rendering, and unstable handling of malformed local turn files.
+
+Checks and mitigations:
+- Route scope is read-only (`GET` only) and constrained to the configured workspace root.
+- Project lookup is ID-based over discovered repos; unknown IDs return `404`.
+- HTML content is escaped (`safeText`) and boot JSON escapes `<` to reduce script injection risk.
+- Turn context parse failures are handled explicitly and returned as non-crashing status cards.
+- No credentials, tokens, or remote network calls are introduced by this UI slice.

--- a/.vibe/reviews/16/ux.md
+++ b/.vibe/reviews/16/ux.md
@@ -29,3 +29,15 @@ UX findings addressed: selector now has explicit keyboard focus styling and mini
 
 ### Findings
 - none
+
+## Run 2026-03-02T19:53:14.521Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Keyboard focus visibility, minimum control sizing, and missing-turn activation affordance were improved; no UX/system-consistency findings remain under the stated assumptions.
+
+### Findings
+- none

--- a/.vibe/reviews/16/ux.md
+++ b/.vibe/reviews/16/ux.md
@@ -17,3 +17,15 @@ Visual foundation is solid, but accessibility/system consistency has two actiona
 ### Findings
 - [P2] Interactive focus state is not explicitly styled for keyboard navigation (src/ui/cockpit.ts:166)
 - [P2] Project selector target size is below recommended minimum touch target (src/ui/cockpit.ts:166)
+
+## Run 2026-03-02T19:51:29Z
+- run_id: issue-16-review-pass-2
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+UX findings addressed: selector now has explicit keyboard focus styling and minimum touch target sizing; missing-turn CTA is visible in-card.
+
+### Findings
+- none

--- a/.vibe/reviews/16/ux.md
+++ b/.vibe/reviews/16/ux.md
@@ -1,0 +1,6 @@
+## Run 2026-03-02T19:43:57Z
+UX/frontend pass:
+- Implemented a distinct visual direction (warm/cool gradient atmosphere, non-default typography, card reveal animation) while keeping readability and hierarchy clear.
+- Ensured responsive behavior with a mobile breakpoint collapsing sidebar/main into a single-column flow.
+- Added explicit labels and selector semantics (`aria-label`) for baseline accessibility.
+- Included future-ready panel placeholders (Run Planner / Deploy Rail) so next UI slices can grow without structural rework.

--- a/.vibe/reviews/16/ux.md
+++ b/.vibe/reviews/16/ux.md
@@ -4,3 +4,16 @@ UX/frontend pass:
 - Ensured responsive behavior with a mobile breakpoint collapsing sidebar/main into a single-column flow.
 - Added explicit labels and selector semantics (`aria-label`) for baseline accessibility.
 - Included future-ready panel placeholders (Run Planner / Deploy Rail) so next UI slices can grow without structural rework.
+
+## Run 2026-03-02T19:48:15.949Z
+- run_id: issue-16-review-pass-1
+- attempt: 1/5
+- findings: 2
+- autofix_applied: no
+
+### Summary
+Visual foundation is solid, but accessibility/system consistency has two actionable gaps.
+
+### Findings
+- [P2] Interactive focus state is not explicitly styled for keyboard navigation (src/ui/cockpit.ts:166)
+- [P2] Project selector target size is below recommended minimum touch target (src/ui/cockpit.ts:166)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ vibe postflight --apply
 `init`/`update` also scaffold a managed README workflow section (`<!-- vibe:workflow-docs:start --> ... <!-- vibe:workflow-docs:end -->`) with a Mermaid diagram, preserving non-managed README content.
 `update --json` includes `readme_workflow_status` with one of: `created` (workflow block created, including first insertion into an existing README), `updated` (existing managed block refreshed), `unchanged` (already up-to-date), `repaired` (malformed markers were repaired).
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
+`ui serve` boots a local cockpit shell with workspace project selector + baseline branch/turn/issue cards (`node dist/cli.cjs ui serve --workspace <path>`).
 `turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 `turn start --issue <n>` now enforces a remote-state guard (`git fetch origin`, `git status -sb`, `git branch -vv`, PR state check on current branch) and blocks branch creation on behind/diverged or closed/merged-PR branch states with explicit remediation commands.
 `postflight --apply` now runs automatic local branch cleanup for `upstream gone` branches (safe delete for merged, force delete for patch-equivalent, non-merged require explicit manual confirmation). Use `--skip-branch-cleanup` to bypass it.
@@ -205,6 +206,7 @@ node dist/cli.cjs tracker bootstrap --dry-run
 node dist/cli.cjs tracker bootstrap
 node dist/cli.cjs tracker reconcile --dry-run
 node dist/cli.cjs tracker reconcile --fallback-module module:core --fallback-milestone "<milestone>"
+node dist/cli.cjs ui serve --workspace /path/to/projects
 node dist/cli.cjs postflight
 node dist/cli.cjs postflight --apply --dry-run
 node dist/cli.cjs postflight --apply

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ vibe postflight --apply
 `init`/`update` also scaffold a managed README workflow section (`<!-- vibe:workflow-docs:start --> ... <!-- vibe:workflow-docs:end -->`) with a Mermaid diagram, preserving non-managed README content.
 `update --json` includes `readme_workflow_status` with one of: `created` (workflow block created, including first insertion into an existing README), `updated` (existing managed block refreshed), `unchanged` (already up-to-date), `repaired` (malformed markers were repaired).
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
-`ui serve` boots a local cockpit shell with workspace project selector + baseline branch/turn/issue cards (`node dist/cli.cjs ui serve --workspace <path>`).
+`ui serve` boots a local cockpit shell with workspace project selector + baseline branch/turn/issue cards (`node dist/cli.cjs ui serve --workspace <path>`). Non-loopback hosts require explicit `--allow-remote`.
 `turn start --issue <n>` now auto-creates `.vibe/reviews/<n>/` templates (`implementation`, `security`, `quality`, `ux`, `ops`) when missing.
 `turn start --issue <n>` now enforces a remote-state guard (`git fetch origin`, `git status -sb`, `git branch -vv`, PR state check on current branch) and blocks branch creation on behind/diverged or closed/merged-PR branch states with explicit remediation commands.
 `postflight --apply` now runs automatic local branch cleanup for `upstream gone` branches (safe delete for merged, force delete for patch-equivalent, non-merged require explicit manual confirmation). Use `--skip-branch-cleanup` to bypass it.

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -359,6 +359,23 @@ function parsePortNumber(value: unknown): number | null {
   return parsed >= 0 && parsed <= 65535 ? parsed : null;
 }
 
+function isLoopbackHost(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1") return true;
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1) === "::1";
+  }
+  return false;
+}
+
+function extractErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) return null;
+  if (!("code" in error)) return null;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" && code.trim() ? code.trim() : null;
+}
+
 function parseLabelNames(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -1963,6 +1980,7 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
     .option("--host <host>", "Host to bind", "127.0.0.1")
     .option("--port <n>", "Port to bind (0-65535)", "4173")
     .option("--workspace <path>", "Workspace root path", process.cwd())
+    .option("--allow-remote", "Allow non-loopback host binding", false)
     .action(async (opts) => {
       const host = typeof opts.host === "string" ? opts.host.trim() : "";
       if (!host) {
@@ -1978,11 +1996,22 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         return;
       }
 
+      const allowRemote = Boolean(opts.allowRemote);
+      if (!isLoopbackHost(host) && !allowRemote) {
+        console.error(`ui serve: host '${host}' is non-loopback and can expose local metadata to your network.`);
+        console.error("ui serve: use --allow-remote to confirm intentional remote binding, or bind to 127.0.0.1.");
+        process.exitCode = 1;
+        return;
+      }
+
       const workspaceRoot =
         typeof opts.workspace === "string" && opts.workspace.trim() ? opts.workspace.trim() : process.cwd();
 
       try {
         const handle = await startCockpitServer({ host, port, workspaceRoot });
+        if (!isLoopbackHost(host)) {
+          console.log("ui: remote binding enabled (--allow-remote).");
+        }
         console.log(`ui: serving local cockpit at ${handle.url}`);
         console.log(`ui: workspace root ${handle.workspaceRoot}`);
         console.log("ui: press Ctrl+C to stop.");
@@ -2009,7 +2038,20 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         });
       } catch (error) {
         console.error("ui serve: ERROR");
-        console.error(error);
+        if (error instanceof Error && error.message) {
+          console.error(error.message);
+        } else {
+          console.error(error);
+        }
+
+        const errorCode = extractErrorCode(error);
+        if (errorCode === "EADDRINUSE") {
+          console.error("ui serve remediation: selected port is already in use.");
+          console.error("ui serve remediation: retry with --port <open-port> (for example 4174).");
+        } else if (errorCode === "EACCES" || errorCode === "EPERM") {
+          console.error("ui serve remediation: current environment denied binding this address/port.");
+          console.error("ui serve remediation: retry with --host 127.0.0.1 --port 4173.");
+        }
         process.exitCode = 1;
       }
     });

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -44,6 +44,7 @@ import {
   type SecurityScanResult,
 } from "./core/security-scan";
 import { checkToolUpdate, runToolSelfUpdate } from "./core/update";
+import { startCockpitServer, stopCockpitServer } from "./ui/cockpit";
 
 type ExecaFn = typeof execa;
 const GUARD_NO_ACTIVE_TURN_EXIT_CODE = 2;
@@ -342,6 +343,20 @@ function parseNullableString(value: unknown): string | null {
 
 function parsePositiveInt(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function parsePortNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    if (!Number.isInteger(value)) return null;
+    return value >= 0 && value <= 65535 ? value : null;
+  }
+
+  if (typeof value !== "string") return null;
+  if (!/^[0-9]+$/.test(value.trim())) return null;
+
+  const parsed = Number(value.trim());
+  if (!Number.isInteger(parsed)) return null;
+  return parsed >= 0 && parsed <= 65535 ? parsed : null;
 }
 
 function parseLabelNames(value: unknown): string[] {
@@ -1937,6 +1952,65 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         } catch {
           console.log("\nBranch PRs: unavailable");
         }
+      }
+    });
+
+  const ui = program.command("ui").description("Local cockpit web UI");
+
+  ui
+    .command("serve")
+    .description("Start dashboard shell with workspace project selector")
+    .option("--host <host>", "Host to bind", "127.0.0.1")
+    .option("--port <n>", "Port to bind (0-65535)", "4173")
+    .option("--workspace <path>", "Workspace root path", process.cwd())
+    .action(async (opts) => {
+      const host = typeof opts.host === "string" ? opts.host.trim() : "";
+      if (!host) {
+        console.error("ui serve: --host cannot be empty.");
+        process.exitCode = 1;
+        return;
+      }
+
+      const port = parsePortNumber(opts.port);
+      if (port === null) {
+        console.error("ui serve: --port must be an integer between 0 and 65535.");
+        process.exitCode = 1;
+        return;
+      }
+
+      const workspaceRoot =
+        typeof opts.workspace === "string" && opts.workspace.trim() ? opts.workspace.trim() : process.cwd();
+
+      try {
+        const handle = await startCockpitServer({ host, port, workspaceRoot });
+        console.log(`ui: serving local cockpit at ${handle.url}`);
+        console.log(`ui: workspace root ${handle.workspaceRoot}`);
+        console.log("ui: press Ctrl+C to stop.");
+
+        let shuttingDown = false;
+        const shutdown = async (signal: "SIGINT" | "SIGTERM"): Promise<void> => {
+          if (shuttingDown) return;
+          shuttingDown = true;
+          console.log(`\nui: received ${signal}; shutting down.`);
+          try {
+            await stopCockpitServer(handle);
+          } catch (error) {
+            console.error("ui: shutdown warning");
+            console.error(error);
+          }
+          process.exit(0);
+        };
+
+        process.once("SIGINT", () => {
+          void shutdown("SIGINT");
+        });
+        process.once("SIGTERM", () => {
+          void shutdown("SIGTERM");
+        });
+      } catch (error) {
+        console.error("ui serve: ERROR");
+        console.error(error);
+        process.exitCode = 1;
       }
     });
 

--- a/src/ui/cockpit.ts
+++ b/src/ui/cockpit.ts
@@ -1,0 +1,868 @@
+import { createServer, type IncomingMessage, type Server as HttpServer, type ServerResponse } from "node:http";
+import { access, readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { execa } from "execa";
+
+type StatusCard = {
+  value: string;
+  hint: string;
+};
+
+type TurnContextProbe =
+  | {
+      status: "missing";
+    }
+  | {
+      status: "invalid";
+      reason: string;
+    }
+  | {
+      status: "active";
+      issueId: number | null;
+      branch: string | null;
+      startedAt: string | null;
+    };
+
+export type CockpitProjectSummary = {
+  id: string;
+  name: string;
+  path: string;
+  hasVibe: boolean;
+};
+
+export type CockpitProjectsSnapshot = {
+  workspaceRoot: string;
+  projects: CockpitProjectSummary[];
+  selectedProjectId: string | null;
+};
+
+export type CockpitProjectStatus = {
+  projectId: string;
+  projectName: string;
+  projectPath: string;
+  branch: StatusCard;
+  turn: StatusCard;
+  issue: StatusCard;
+  updatedAt: string;
+};
+
+export type CockpitServerHandle = {
+  server: HttpServer;
+  workspaceRoot: string;
+  host: string;
+  port: number;
+  url: string;
+};
+
+export type StartCockpitServerOptions = {
+  workspaceRoot: string;
+  host?: string;
+  port?: number;
+};
+
+export type CockpitRouteRequest = {
+  method?: string | null;
+  url?: string | null;
+  workspaceRoot: string;
+};
+
+export type CockpitRouteResponse = {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+};
+
+const DASHBOARD_STYLE = `
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=IBM+Plex+Mono:wght@400;500&display=swap");
+
+:root {
+  --bg-top: #f7f2ea;
+  --bg-bottom: #e5eef5;
+  --ink: #162130;
+  --ink-soft: #3f5368;
+  --line: rgba(26, 41, 56, 0.14);
+  --panel: rgba(255, 255, 255, 0.78);
+  --accent-main: #0c8e86;
+  --accent-alt: #f47c20;
+  --shadow: 0 18px 40px rgba(19, 35, 52, 0.14);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(1200px 500px at -10% -15%, rgba(244, 124, 32, 0.24), transparent 62%),
+    radial-gradient(900px 450px at 120% -10%, rgba(12, 142, 134, 0.22), transparent 58%),
+    linear-gradient(165deg, var(--bg-top), var(--bg-bottom));
+}
+
+.shell {
+  max-width: 1160px;
+  margin: 2.4rem auto;
+  border: 1px solid var(--line);
+  border-radius: 26px;
+  background: var(--panel);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+}
+
+.shell-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 1.25rem 1.6rem;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(90deg, rgba(12, 142, 134, 0.14), rgba(244, 124, 32, 0.08));
+}
+
+.brand {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.header-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink-soft);
+}
+
+.shell-body {
+  display: grid;
+  grid-template-columns: minmax(250px, 290px) minmax(0, 1fr);
+  min-height: 520px;
+}
+
+.shell-sidebar {
+  border-right: 1px solid var(--line);
+  padding: 1.3rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.label {
+  margin: 0;
+  font-size: 0.79rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+#project-selector {
+  width: 100%;
+  margin-top: 0.35rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 0.72rem 0.76rem;
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--ink);
+  font-family: "Space Grotesk", "Segoe UI", sans-serif;
+  font-size: 0.95rem;
+}
+
+.mono-chip {
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.68);
+  padding: 0.7rem 0.8rem;
+  font-family: "IBM Plex Mono", "Menlo", monospace;
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.meta-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.meta-list li {
+  font-size: 0.89rem;
+}
+
+.meta-key {
+  color: var(--ink-soft);
+}
+
+.shell-main {
+  padding: 1.35rem;
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.status-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.status-card {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 0.95rem;
+  opacity: 0;
+  transform: translateY(6px);
+  animation: card-rise 420ms ease forwards;
+}
+
+.status-card:nth-child(2) {
+  animation-delay: 90ms;
+}
+
+.status-card:nth-child(3) {
+  animation-delay: 170ms;
+}
+
+.status-title {
+  margin: 0;
+  font-size: 0.74rem;
+  color: var(--ink-soft);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.status-value {
+  margin: 0.45rem 0 0;
+  font-size: 1.13rem;
+  font-weight: 600;
+}
+
+.status-hint {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+}
+
+.panel-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 1rem;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.panel p {
+  margin: 0.6rem 0 0;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.accent {
+  color: var(--accent-main);
+  font-weight: 600;
+}
+
+@media (max-width: 920px) {
+  .shell {
+    margin: 1.1rem;
+  }
+
+  .shell-body {
+    grid-template-columns: 1fr;
+  }
+
+  .shell-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .status-grid,
+  .panel-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@keyframes card-rise {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+`;
+
+const DASHBOARD_SCRIPT = `
+(() => {
+  const bootNode = document.getElementById("vibe-cockpit-boot");
+  const boot = bootNode && bootNode.textContent ? JSON.parse(bootNode.textContent) : {};
+
+  const selector = document.getElementById("project-selector");
+  const workspacePath = document.getElementById("workspace-path");
+  const repoCount = document.getElementById("repo-count");
+  const selectedPath = document.getElementById("project-path");
+  const branchValue = document.getElementById("branch-value");
+  const branchHint = document.getElementById("branch-hint");
+  const turnValue = document.getElementById("turn-value");
+  const turnHint = document.getElementById("turn-hint");
+  const issueValue = document.getElementById("issue-value");
+  const issueHint = document.getElementById("issue-hint");
+
+  const projects = Array.isArray(boot.projects) ? boot.projects : [];
+  const selectedInitial = typeof boot.selectedProjectId === "string" ? boot.selectedProjectId : "";
+  const initialStatus = boot.initialStatus && typeof boot.initialStatus === "object" ? boot.initialStatus : null;
+  const workspaceRoot = typeof boot.workspaceRoot === "string" ? boot.workspaceRoot : "";
+
+  if (workspacePath) workspacePath.textContent = workspaceRoot || "(not set)";
+  if (repoCount) repoCount.textContent = String(projects.length);
+
+  function setText(node, value) {
+    if (node) node.textContent = value;
+  }
+
+  function renderStatus(status) {
+    if (!status) {
+      setText(selectedPath, "(select a repository)");
+      setText(branchValue, "Unavailable");
+      setText(branchHint, "No repository selected.");
+      setText(turnValue, "No active turn");
+      setText(turnHint, "Select a repository.");
+      setText(issueValue, "Pending link");
+      setText(issueHint, "Select a repository to inspect.");
+      return;
+    }
+
+    setText(selectedPath, status.projectPath || "-");
+    setText(branchValue, status.branch && status.branch.value ? status.branch.value : "Unavailable");
+    setText(branchHint, status.branch && status.branch.hint ? status.branch.hint : "");
+    setText(turnValue, status.turn && status.turn.value ? status.turn.value : "No active turn");
+    setText(turnHint, status.turn && status.turn.hint ? status.turn.hint : "");
+    setText(issueValue, status.issue && status.issue.value ? status.issue.value : "Pending link");
+    setText(issueHint, status.issue && status.issue.hint ? status.issue.hint : "");
+  }
+
+  async function fetchStatus(projectId) {
+    if (!projectId) {
+      renderStatus(null);
+      return;
+    }
+
+    try {
+      const response = await fetch("/api/project-status?project=" + encodeURIComponent(projectId));
+      if (!response.ok) throw new Error("status request failed");
+      const data = await response.json();
+      renderStatus(data);
+    } catch {
+      renderStatus({
+        projectPath: "(request failed)",
+        branch: { value: "Unavailable", hint: "Could not load branch status." },
+        turn: { value: "No active turn", hint: "Could not load turn status." },
+        issue: { value: "Pending link", hint: "Could not load issue placeholder." }
+      });
+    }
+  }
+
+  if (selector) {
+    selector.innerHTML = "";
+    if (!projects.length) {
+      const option = document.createElement("option");
+      option.value = "";
+      option.textContent = "No repositories found";
+      selector.append(option);
+      selector.disabled = true;
+    } else {
+      for (const project of projects) {
+        const option = document.createElement("option");
+        option.value = project.id;
+        option.textContent = project.name + (project.hasVibe ? " (vibe)" : "");
+        selector.append(option);
+      }
+      selector.value = selectedInitial || projects[0].id;
+      selector.addEventListener("change", () => {
+        void fetchStatus(selector.value);
+      });
+    }
+  }
+
+  if (initialStatus) {
+    renderStatus(initialStatus);
+  } else if (selector && selector.value) {
+    void fetchStatus(selector.value);
+  } else {
+    renderStatus(null);
+  }
+})();
+`;
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeRelativePath(relativePath: string): string {
+  if (!relativePath || relativePath === ".") {
+    return ".";
+  }
+  return relativePath.replaceAll(path.sep, "/");
+}
+
+function toProjectId(relativePath: string): string {
+  return encodeURIComponent(normalizeRelativePath(relativePath));
+}
+
+function safeText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function safeJson(value: unknown): string {
+  return JSON.stringify(value).replaceAll("<", "\\u003c");
+}
+
+async function resolveTurnContext(projectPath: string): Promise<TurnContextProbe> {
+  const turnPath = path.join(projectPath, ".vibe", "runtime", "turn.json");
+  if (!(await pathExists(turnPath))) {
+    return { status: "missing" };
+  }
+
+  try {
+    const raw = await readFile(turnPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return { status: "invalid", reason: "turn.json is not an object" };
+    }
+
+    const item = parsed as Record<string, unknown>;
+    const issueIdCandidate = item.issue_id;
+    const issueId =
+      typeof issueIdCandidate === "number" && Number.isInteger(issueIdCandidate) && issueIdCandidate > 0
+        ? issueIdCandidate
+        : null;
+    const branch = typeof item.branch === "string" && item.branch.trim() ? item.branch.trim() : null;
+    const startedAt = typeof item.started_at === "string" && item.started_at.trim() ? item.started_at.trim() : null;
+
+    return {
+      status: "active",
+      issueId,
+      branch,
+      startedAt,
+    };
+  } catch (error) {
+    const reason = error instanceof Error && error.message ? error.message : "unable to parse turn.json";
+    return { status: "invalid", reason };
+  }
+}
+
+async function resolveBranch(projectPath: string): Promise<string | null> {
+  try {
+    const result = await execa("git", ["-C", projectPath, "rev-parse", "--abbrev-ref", "HEAD"], {
+      stdio: "pipe",
+      reject: false,
+    });
+    if (result.exitCode !== 0) {
+      return null;
+    }
+
+    const branch = result.stdout.trim();
+    if (!branch || branch === "HEAD") {
+      return null;
+    }
+    return branch;
+  } catch {
+    return null;
+  }
+}
+
+function buildBranchCard(branch: string | null): StatusCard {
+  if (branch) {
+    return {
+      value: branch,
+      hint: "Detected from git HEAD.",
+    };
+  }
+
+  return {
+    value: "Unavailable",
+    hint: "Could not resolve git branch from this project.",
+  };
+}
+
+function buildTurnCard(turn: TurnContextProbe): StatusCard {
+  if (turn.status === "missing") {
+    return {
+      value: "No active turn",
+      hint: "Run `vibe turn start --issue <n>` in this project.",
+    };
+  }
+
+  if (turn.status === "invalid") {
+    return {
+      value: "Invalid turn context",
+      hint: turn.reason,
+    };
+  }
+
+  const issueText = turn.issueId ? `#${turn.issueId}` : "issue pending";
+  const branchText = turn.branch ?? "branch pending";
+  const value = `${issueText} · ${branchText}`;
+  return {
+    value,
+    hint: turn.startedAt ? `Started at ${turn.startedAt}.` : "Active turn loaded from .vibe/runtime/turn.json.",
+  };
+}
+
+function buildIssueCard(turn: TurnContextProbe): StatusCard {
+  if (turn.status === "active" && turn.issueId) {
+    return {
+      value: `#${turn.issueId}`,
+      hint: "Linked from active turn context.",
+    };
+  }
+
+  return {
+    value: "Pending link",
+    hint: "Issue hydration panel will be added in the next UI slices.",
+  };
+}
+
+function buildDashboardHtml(snapshot: CockpitProjectsSnapshot, initialStatus: CockpitProjectStatus | null): string {
+  const bootPayload = safeJson({
+    workspaceRoot: snapshot.workspaceRoot,
+    projects: snapshot.projects,
+    selectedProjectId: snapshot.selectedProjectId,
+    initialStatus,
+  });
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Vibe Cockpit</title>
+    <style>${DASHBOARD_STYLE}</style>
+  </head>
+  <body>
+    <div class="shell">
+      <header class="shell-header">
+        <h1 class="brand">Vibe Cockpit</h1>
+        <p class="header-note">UI shell for local run/deploy workflows</p>
+      </header>
+      <div class="shell-body">
+        <aside class="shell-sidebar">
+          <div>
+            <p class="label">Workspace root</p>
+            <p id="workspace-path" class="mono-chip">${safeText(snapshot.workspaceRoot)}</p>
+          </div>
+          <div>
+            <p class="label">Project selector</p>
+            <select id="project-selector" aria-label="Project selector"></select>
+          </div>
+          <div>
+            <p class="label">Selected path</p>
+            <p id="project-path" class="mono-chip">${safeText(initialStatus?.projectPath ?? "(select a repository)")}</p>
+          </div>
+          <ul class="meta-list">
+            <li><span class="meta-key">Repositories:</span> <strong id="repo-count">${snapshot.projects.length}</strong></li>
+            <li><span class="meta-key">Mode:</span> local cockpit shell</li>
+            <li><span class="meta-key">Focus:</span> <span class="accent">safe run + deploy lanes</span></li>
+          </ul>
+        </aside>
+        <main class="shell-main">
+          <section class="status-grid" aria-label="Status cards">
+            <article class="status-card">
+              <p class="status-title">Branch</p>
+              <p id="branch-value" class="status-value">${safeText(initialStatus?.branch.value ?? "Unavailable")}</p>
+              <p id="branch-hint" class="status-hint">${safeText(initialStatus?.branch.hint ?? "No repository selected.")}</p>
+            </article>
+            <article class="status-card">
+              <p class="status-title">Turn</p>
+              <p id="turn-value" class="status-value">${safeText(initialStatus?.turn.value ?? "No active turn")}</p>
+              <p id="turn-hint" class="status-hint">${safeText(initialStatus?.turn.hint ?? "Select a repository.")}</p>
+            </article>
+            <article class="status-card">
+              <p class="status-title">Issue Link</p>
+              <p id="issue-value" class="status-value">${safeText(initialStatus?.issue.value ?? "Pending link")}</p>
+              <p id="issue-hint" class="status-hint">${safeText(initialStatus?.issue.hint ?? "Select a repository.")}</p>
+            </article>
+          </section>
+          <section class="panel-grid" aria-label="Future workflow panels">
+            <article class="panel">
+              <h2>Run Planner</h2>
+              <p>Reserved panel for <code>preflight</code>, tests, and review flows. This shell keeps room for actionable controls without layout churn.</p>
+            </article>
+            <article class="panel">
+              <h2>Deploy Rail</h2>
+              <p>Reserved panel for postflight apply, release checks, and audit traces. The structure is ready for future deployment-safe interactions.</p>
+            </article>
+          </section>
+        </main>
+      </div>
+    </div>
+    <script id="vibe-cockpit-boot" type="application/json">${bootPayload}</script>
+    <script>${DASHBOARD_SCRIPT}</script>
+  </body>
+</html>`;
+}
+
+async function discoverProjectCandidates(workspaceRoot: string): Promise<string[]> {
+  const candidates = [workspaceRoot];
+
+  try {
+    const entries = await readdir(workspaceRoot, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      candidates.push(path.join(workspaceRoot, entry.name));
+    }
+  } catch {
+    // No directory listing permissions or missing workspace root.
+  }
+
+  return candidates;
+}
+
+export async function discoverWorkspaceProjects(workspaceRoot: string): Promise<CockpitProjectSummary[]> {
+  const resolvedRoot = path.resolve(workspaceRoot);
+  const candidates = await discoverProjectCandidates(resolvedRoot);
+  const projects: CockpitProjectSummary[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) continue;
+    seen.add(candidate);
+
+    const gitMarker = path.join(candidate, ".git");
+    if (!(await pathExists(gitMarker))) {
+      continue;
+    }
+
+    const relativeRaw = path.relative(resolvedRoot, candidate);
+    const relativePath = relativeRaw ? normalizeRelativePath(relativeRaw) : ".";
+    const hasVibe = await pathExists(path.join(candidate, ".vibe"));
+    projects.push({
+      id: toProjectId(relativePath),
+      name: relativePath === "." ? path.basename(resolvedRoot) || "." : path.basename(candidate),
+      path: candidate,
+      hasVibe,
+    });
+  }
+
+  projects.sort((left, right) => {
+    if (left.path === resolvedRoot) return -1;
+    if (right.path === resolvedRoot) return 1;
+    return left.name.localeCompare(right.name);
+  });
+
+  return projects;
+}
+
+export async function readProjectStatus(project: CockpitProjectSummary): Promise<CockpitProjectStatus> {
+  const [branch, turn] = await Promise.all([resolveBranch(project.path), resolveTurnContext(project.path)]);
+
+  return {
+    projectId: project.id,
+    projectName: project.name,
+    projectPath: project.path,
+    branch: buildBranchCard(branch),
+    turn: buildTurnCard(turn),
+    issue: buildIssueCard(turn),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+async function readProjectsSnapshot(workspaceRoot: string): Promise<CockpitProjectsSnapshot> {
+  const resolvedRoot = path.resolve(workspaceRoot);
+  const projects = await discoverWorkspaceProjects(resolvedRoot);
+  return {
+    workspaceRoot: resolvedRoot,
+    projects,
+    selectedProjectId: projects[0]?.id ?? null,
+  };
+}
+
+function writeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+  });
+  response.end(JSON.stringify(payload));
+}
+
+function jsonResponse(statusCode: number, payload: unknown): CockpitRouteResponse {
+  return {
+    statusCode,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+    body: JSON.stringify(payload),
+  };
+}
+
+function htmlResponse(html: string): CockpitRouteResponse {
+  return {
+    statusCode: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+    },
+    body: html,
+  };
+}
+
+async function resolveProjectById(workspaceRoot: string, projectId: string): Promise<CockpitProjectSummary | null> {
+  const projects = await discoverWorkspaceProjects(workspaceRoot);
+  return projects.find((project) => project.id === projectId) ?? null;
+}
+
+export async function routeCockpitRequest(request: CockpitRouteRequest): Promise<CockpitRouteResponse> {
+  const requestMethod = (request.method ?? "GET").toUpperCase();
+  if (requestMethod !== "GET") {
+    return jsonResponse(405, { error: "method_not_allowed" });
+  }
+
+  const workspaceRoot = path.resolve(request.workspaceRoot);
+  const requestUrl = new URL(request.url ?? "/", "http://localhost");
+  if (requestUrl.pathname === "/healthz") {
+    return jsonResponse(200, { ok: true });
+  }
+
+  if (requestUrl.pathname === "/api/projects") {
+    const snapshot = await readProjectsSnapshot(workspaceRoot);
+    return jsonResponse(200, snapshot);
+  }
+
+  if (requestUrl.pathname === "/api/project-status") {
+    const projectId = requestUrl.searchParams.get("project");
+    if (!projectId) {
+      return jsonResponse(400, { error: "missing_project_id" });
+    }
+
+    const project = await resolveProjectById(workspaceRoot, projectId);
+    if (!project) {
+      return jsonResponse(404, { error: "project_not_found" });
+    }
+
+    const status = await readProjectStatus(project);
+    return jsonResponse(200, status);
+  }
+
+  if (requestUrl.pathname === "/favicon.ico") {
+    return {
+      statusCode: 204,
+      headers: {},
+      body: "",
+    };
+  }
+
+  if (requestUrl.pathname !== "/") {
+    return jsonResponse(404, { error: "not_found" });
+  }
+
+  const snapshot = await readProjectsSnapshot(workspaceRoot);
+  const selected = snapshot.projects.find((project) => project.id === snapshot.selectedProjectId) ?? null;
+  const initialStatus = selected ? await readProjectStatus(selected) : null;
+  return htmlResponse(buildDashboardHtml(snapshot, initialStatus));
+}
+
+async function handleCockpitRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  workspaceRoot: string,
+): Promise<void> {
+  const routed = await routeCockpitRequest({
+    method: request.method ?? "GET",
+    url: request.url ?? "/",
+    workspaceRoot,
+  });
+
+  response.writeHead(routed.statusCode, routed.headers);
+  response.end(routed.body);
+}
+
+export async function startCockpitServer(options: StartCockpitServerOptions): Promise<CockpitServerHandle> {
+  const workspaceRoot = path.resolve(options.workspaceRoot);
+  const host = options.host?.trim() || "127.0.0.1";
+  const port = Number.isInteger(options.port) ? (options.port as number) : 4173;
+
+  const server = createServer((request, response) => {
+    void handleCockpitRequest(request, response, workspaceRoot).catch((error) => {
+      const detail = error instanceof Error && error.message ? error.message : String(error);
+      writeJson(response, 500, { error: "internal_error", detail });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = (): void => {
+      server.off("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(port, host);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    throw new Error("ui server: unable to resolve listening address");
+  }
+
+  const hostForUrl = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  return {
+    server,
+    workspaceRoot,
+    host: address.address,
+    port: address.port,
+    url: `http://${hostForUrl}:${address.port}`,
+  };
+}
+
+export async function stopCockpitServer(handle: CockpitServerHandle): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    handle.server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}

--- a/src/ui/cockpit.ts
+++ b/src/ui/cockpit.ts
@@ -169,10 +169,17 @@ body {
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 0.72rem 0.76rem;
+  min-height: 46px;
   background: rgba(255, 255, 255, 0.94);
   color: var(--ink);
   font-family: "Space Grotesk", "Segoe UI", sans-serif;
   font-size: 0.95rem;
+}
+
+#project-selector:focus-visible {
+  outline: 3px solid rgba(12, 142, 134, 0.35);
+  outline-offset: 2px;
+  border-color: rgba(12, 142, 134, 0.9);
 }
 
 .mono-chip {
@@ -254,6 +261,23 @@ body {
   color: var(--ink-soft);
 }
 
+.turn-cta {
+  display: none;
+  margin: 0.5rem 0 0;
+  border: 1px solid rgba(12, 142, 134, 0.28);
+  border-radius: 10px;
+  background: rgba(12, 142, 134, 0.08);
+  padding: 0.55rem 0.62rem;
+  font-family: "IBM Plex Mono", "Menlo", monospace;
+  font-size: 0.76rem;
+  color: #0b655f;
+  overflow-wrap: anywhere;
+}
+
+.turn-cta.visible {
+  display: block;
+}
+
 .panel-grid {
   display: grid;
   gap: 0.8rem;
@@ -331,6 +355,7 @@ const DASHBOARD_SCRIPT = `
   const turnHint = document.getElementById("turn-hint");
   const issueValue = document.getElementById("issue-value");
   const issueHint = document.getElementById("issue-hint");
+  const turnCta = document.getElementById("turn-cta");
 
   const projects = Array.isArray(boot.projects) ? boot.projects : [];
   const selectedInitial = typeof boot.selectedProjectId === "string" ? boot.selectedProjectId : "";
@@ -340,8 +365,27 @@ const DASHBOARD_SCRIPT = `
   if (workspacePath) workspacePath.textContent = workspaceRoot || "(not set)";
   if (repoCount) repoCount.textContent = String(projects.length);
 
+  function emitMetric(eventName, payload) {
+    try {
+      const sink = window.__VIBE_COCKPIT_TELEMETRY__;
+      if (typeof sink !== "function") return;
+      sink({
+        event: eventName,
+        at: new Date().toISOString(),
+        ...payload
+      });
+    } catch {
+      // Non-blocking telemetry hook.
+    }
+  }
+
   function setText(node, value) {
     if (node) node.textContent = value;
+  }
+
+  function setTurnCtaVisible(visible) {
+    if (!turnCta) return;
+    turnCta.classList.toggle("visible", Boolean(visible));
   }
 
   function renderStatus(status) {
@@ -353,6 +397,7 @@ const DASHBOARD_SCRIPT = `
       setText(turnHint, "Select a repository.");
       setText(issueValue, "Pending link");
       setText(issueHint, "Select a repository to inspect.");
+      setTurnCtaVisible(true);
       return;
     }
 
@@ -363,6 +408,11 @@ const DASHBOARD_SCRIPT = `
     setText(turnHint, status.turn && status.turn.hint ? status.turn.hint : "");
     setText(issueValue, status.issue && status.issue.value ? status.issue.value : "Pending link");
     setText(issueHint, status.issue && status.issue.hint ? status.issue.hint : "");
+    const hasNoTurn = String(status.turn && status.turn.value ? status.turn.value : "")
+      .trim()
+      .toLowerCase()
+      .startsWith("no active turn");
+    setTurnCtaVisible(hasNoTurn);
   }
 
   async function fetchStatus(projectId) {
@@ -376,6 +426,7 @@ const DASHBOARD_SCRIPT = `
       if (!response.ok) throw new Error("status request failed");
       const data = await response.json();
       renderStatus(data);
+      emitMetric("status_loaded", { projectId });
     } catch {
       renderStatus({
         projectPath: "(request failed)",
@@ -383,6 +434,7 @@ const DASHBOARD_SCRIPT = `
         turn: { value: "No active turn", hint: "Could not load turn status." },
         issue: { value: "Pending link", hint: "Could not load issue placeholder." }
       });
+      emitMetric("status_load_failed", { projectId });
     }
   }
 
@@ -403,6 +455,7 @@ const DASHBOARD_SCRIPT = `
       }
       selector.value = selectedInitial || projects[0].id;
       selector.addEventListener("change", () => {
+        emitMetric("project_selected", { projectId: selector.value });
         void fetchStatus(selector.value);
       });
     }
@@ -610,6 +663,7 @@ function buildDashboardHtml(snapshot: CockpitProjectsSnapshot, initialStatus: Co
               <p class="status-title">Turn</p>
               <p id="turn-value" class="status-value">${safeText(initialStatus?.turn.value ?? "No active turn")}</p>
               <p id="turn-hint" class="status-hint">${safeText(initialStatus?.turn.hint ?? "Select a repository.")}</p>
+              <p id="turn-cta" class="turn-cta">Run: <code>vibe turn start --issue &lt;n&gt;</code></p>
             </article>
             <article class="status-card">
               <p class="status-title">Issue Link</p>

--- a/tests/cli-ui.test.ts
+++ b/tests/cli-ui.test.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createProgram } from "../src/cli-program";
+
+describe.sequential("cli ui serve", () => {
+  const originalCwd = process.cwd();
+  let tempDir = "";
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "vibe-cli-ui-test-"));
+    process.chdir(tempDir);
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast when --port is outside valid range", async () => {
+    const errors: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((entry) => String(entry)).join(" "));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "ui", "serve", "--port", "70000"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errors.some((line) => line.includes("ui serve: --port must be an integer between 0 and 65535."))).toBe(true);
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/cli-ui.test.ts
+++ b/tests/cli-ui.test.ts
@@ -22,6 +22,8 @@ describe.sequential("cli ui serve", () => {
     process.exitCode = originalExitCode;
     process.chdir(originalCwd);
     vi.restoreAllMocks();
+    vi.doUnmock("../src/ui/cockpit");
+    vi.resetModules();
     if (tempDir) {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -41,5 +43,61 @@ describe.sequential("cli ui serve", () => {
     expect(process.exitCode).toBe(1);
     expect(errors.some((line) => line.includes("ui serve: --port must be an integer between 0 and 65535."))).toBe(true);
     expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks non-loopback hosts unless --allow-remote is explicit", async () => {
+    const errors: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((entry) => String(entry)).join(" "));
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "ui", "serve", "--host", "0.0.0.0"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errors.some((line) => line.includes("host '0.0.0.0' is non-loopback"))).toBe(true);
+  });
+
+  it("runs lifecycle start->shutdown path when SIGINT is emitted", async () => {
+    const logs: string[] = [];
+    const stopCockpitServer = vi.fn(async () => undefined);
+    const startCockpitServer = vi.fn(async () => ({
+      server: {
+        close: (callback: (error?: Error | null) => void): void => callback(null),
+      },
+      workspaceRoot: tempDir,
+      host: "127.0.0.1",
+      port: 4173,
+      url: "http://127.0.0.1:4173",
+    }));
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((entry) => String(entry)).join(" "));
+    });
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      process.exitCode = code ?? 0;
+      return undefined as never;
+    }) as never);
+
+    vi.resetModules();
+    vi.doMock("../src/ui/cockpit", () => ({
+      startCockpitServer,
+      stopCockpitServer,
+    }));
+    const { createProgram: createProgramWithMock } = await import("../src/cli-program");
+    const program = createProgramWithMock(execaMock as never);
+    await program.parseAsync(["node", "vibe", "ui", "serve", "--host", "127.0.0.1", "--port", "4173"]);
+
+    process.emit("SIGINT");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(startCockpitServer).toHaveBeenCalledTimes(1);
+    expect(stopCockpitServer).toHaveBeenCalledTimes(1);
+    expect(logs.some((line) => line.includes("ui: serving local cockpit at http://127.0.0.1:4173"))).toBe(true);
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 });

--- a/tests/ui-cockpit.test.ts
+++ b/tests/ui-cockpit.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { routeCockpitRequest } from "../src/ui/cockpit";
+
+function createRepoFixture(
+  workspaceRoot: string,
+  name: string,
+  options: {
+    withVibe?: boolean;
+    turnIssueId?: number;
+  } = {},
+): string {
+  const repoPath = path.join(workspaceRoot, name);
+  mkdirSync(path.join(repoPath, ".git"), { recursive: true });
+
+  if (options.withVibe) {
+    mkdirSync(path.join(repoPath, ".vibe", "runtime"), { recursive: true });
+  }
+
+  if (typeof options.turnIssueId === "number") {
+    mkdirSync(path.join(repoPath, ".vibe", "runtime"), { recursive: true });
+    writeFileSync(
+      path.join(repoPath, ".vibe", "runtime", "turn.json"),
+      JSON.stringify(
+        {
+          issue_id: options.turnIssueId,
+          branch: `issue-${options.turnIssueId}-fixture`,
+          base_branch: "main",
+          started_at: "2026-03-02T18:00:00.000Z",
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+  }
+
+  return repoPath;
+}
+
+describe.sequential("ui cockpit server", () => {
+  let workspaceRoot = "";
+  let originalCwd = "";
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    workspaceRoot = mkdtempSync(path.join(os.tmpdir(), "vibe-ui-cockpit-test-"));
+    process.chdir(workspaceRoot);
+    createRepoFixture(workspaceRoot, "alpha-repo", { withVibe: true, turnIssueId: 16 });
+    createRepoFixture(workspaceRoot, "beta-repo");
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (workspaceRoot) {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("serves dashboard shell and projects route", async () => {
+    const dashboard = await routeCockpitRequest({
+      method: "GET",
+      url: "/",
+      workspaceRoot,
+    });
+    expect(dashboard.statusCode).toBe(200);
+    expect(dashboard.body).toContain("<title>Vibe Cockpit</title>");
+    expect(dashboard.body).toContain("id=\"project-selector\"");
+    expect(dashboard.body).toContain("UI shell for local run/deploy workflows");
+    expect(dashboard.body).toContain("@media (max-width: 920px)");
+
+    const projectsResponse = await routeCockpitRequest({
+      method: "GET",
+      url: "/api/projects",
+      workspaceRoot,
+    });
+    expect(projectsResponse.statusCode).toBe(200);
+    const projects = JSON.parse(projectsResponse.body) as {
+      workspaceRoot: string;
+      selectedProjectId: string | null;
+      projects: Array<{ id: string; name: string; hasVibe: boolean }>;
+    };
+    expect(projects.workspaceRoot).toBe(path.resolve(workspaceRoot));
+    expect(projects.projects).toHaveLength(2);
+    expect(projects.projects.some((project) => project.name === "alpha-repo" && project.hasVibe)).toBe(true);
+    expect(projects.selectedProjectId).toBeTruthy();
+  });
+
+  it("serves project status and returns 404 for unknown project", async () => {
+    const projectsResponse = await routeCockpitRequest({
+      method: "GET",
+      url: "/api/projects",
+      workspaceRoot,
+    });
+    const projectsPayload = JSON.parse(projectsResponse.body) as {
+      projects: Array<{ id: string; name: string }>;
+    };
+    const alpha = projectsPayload.projects.find((project) => project.name === "alpha-repo");
+    expect(alpha).toBeDefined();
+
+    const statusResponse = await routeCockpitRequest({
+      method: "GET",
+      url: `/api/project-status?project=${encodeURIComponent(alpha!.id)}`,
+      workspaceRoot,
+    });
+    expect(statusResponse.statusCode).toBe(200);
+    const statusPayload = JSON.parse(statusResponse.body) as {
+      projectName: string;
+      turn: { value: string };
+      issue: { value: string };
+    };
+    expect(statusPayload.projectName).toBe("alpha-repo");
+    expect(statusPayload.turn.value).toContain("#16");
+    expect(statusPayload.issue.value).toBe("#16");
+
+    const missingResponse = await routeCockpitRequest({
+      method: "GET",
+      url: "/api/project-status?project=missing-project",
+      workspaceRoot,
+    });
+    expect(missingResponse.statusCode).toBe(404);
+  });
+});

--- a/tests/ui-cockpit.test.ts
+++ b/tests/ui-cockpit.test.ts
@@ -12,6 +12,7 @@ function createRepoFixture(
   options: {
     withVibe?: boolean;
     turnIssueId?: number;
+    turnRaw?: string;
   } = {},
 ): string {
   const repoPath = path.join(workspaceRoot, name);
@@ -37,6 +38,11 @@ function createRepoFixture(
       ),
       "utf8",
     );
+  }
+
+  if (typeof options.turnRaw === "string") {
+    mkdirSync(path.join(repoPath, ".vibe", "runtime"), { recursive: true });
+    writeFileSync(path.join(repoPath, ".vibe", "runtime", "turn.json"), options.turnRaw, "utf8");
   }
 
   return repoPath;
@@ -72,6 +78,8 @@ describe.sequential("ui cockpit server", () => {
     expect(dashboard.body).toContain("id=\"project-selector\"");
     expect(dashboard.body).toContain("UI shell for local run/deploy workflows");
     expect(dashboard.body).toContain("@media (max-width: 920px)");
+    expect(dashboard.body).toContain("__VIBE_COCKPIT_TELEMETRY__");
+    expect(dashboard.body).toContain("id=\"turn-cta\"");
 
     const projectsResponse = await routeCockpitRequest({
       method: "GET",
@@ -123,5 +131,33 @@ describe.sequential("ui cockpit server", () => {
       workspaceRoot,
     });
     expect(missingResponse.statusCode).toBe(404);
+  });
+
+  it("returns invalid turn fallback when turn.json is malformed", async () => {
+    createRepoFixture(workspaceRoot, "gamma-repo", { withVibe: true, turnRaw: "{invalid-json" });
+
+    const projectsResponse = await routeCockpitRequest({
+      method: "GET",
+      url: "/api/projects",
+      workspaceRoot,
+    });
+    const projectsPayload = JSON.parse(projectsResponse.body) as {
+      projects: Array<{ id: string; name: string }>;
+    };
+    const gamma = projectsPayload.projects.find((project) => project.name === "gamma-repo");
+    expect(gamma).toBeDefined();
+
+    const statusResponse = await routeCockpitRequest({
+      method: "GET",
+      url: `/api/project-status?project=${encodeURIComponent(gamma!.id)}`,
+      workspaceRoot,
+    });
+    expect(statusResponse.statusCode).toBe(200);
+    const statusPayload = JSON.parse(statusResponse.body) as {
+      turn: { value: string };
+      issue: { value: string };
+    };
+    expect(statusPayload.turn.value).toBe("Invalid turn context");
+    expect(statusPayload.issue.value).toBe("Pending link");
   });
 });


### PR DESCRIPTION
## Summary
- Issue: #16 feat(ui): dashboard shell for local project cockpit
- Branch: `codex/issue-16-dashboard-shell`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/16

## Architecture decisions
- Scope this PR to issue #16 (`feat(ui): dashboard shell for local project cockpit`) on branch `codex/issue-16-dashboard-shell` in `pr-open` mode.
- Derived from changed files (5): profile=`code+tests+docs`, modules=[cli, docs, tests, ui], sample=`README.md`, `src/cli-program.ts`, `src/ui/cockpit.ts`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Generate reviewer context from issue metadata (`feat(ui): dashboard shell for local project cockpit`; themes=review, tracker, turn, ui; labels=enhancement, module:ui, status:in-review) instead of reusing a boilerplate rationale block.
- Mixed code+tests changes need a rationale that links behavior changes to the test edits in the same PR, which a generic template cannot express.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Keep one fixed rationale bullet set for every PR: rejected because it produces low-signal descriptions across unrelated changes.
- Split code and tests into unrelated narratives: rejected because reviewers need one cohesive explanation for behavior plus verification.
- Claim evidence not present in the signals (sample `README.md`, `src/cli-program.ts`, `src/ui/cockpit.ts`): rejected to keep rationale deterministic and auditable.

Fixes #16