### PR TITLE
#107 bug(pr): rationale sections remain generic in some PRs

### DIFF
--- a/.vibe/reviews/107/growth.md
+++ b/.vibe/reviews/107/growth.md
@@ -1,0 +1,4 @@
+## Run 2026-03-02T20:31:32Z
+Growth pass:
+- More specific rationale copy should improve reviewer trust and reduce clarification churn when sharing PRs externally.
+- This directly supports social proof/readability goals by making each PR narrative visibly tied to concrete changed-file evidence.

--- a/.vibe/reviews/107/growth.md
+++ b/.vibe/reviews/107/growth.md
@@ -2,3 +2,15 @@
 Growth pass:
 - More specific rationale copy should improve reviewer trust and reduce clarification churn when sharing PRs externally.
 - This directly supports social proof/readability goals by making each PR narrative visibly tied to concrete changed-file evidence.
+
+## Run 2026-03-02T20:33:20.178Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+The change improves reviewer trust and shareability by making rationale sections more specific to each PR; no additional growth blockers were found in this slice.
+
+### Findings
+- none

--- a/.vibe/reviews/107/implementation.md
+++ b/.vibe/reviews/107/implementation.md
@@ -1,0 +1,5 @@
+## Run 2026-03-02T20:31:32Z
+- Scope: issue #107 (`bug(pr): rationale sections remain generic in some PRs`).
+- Updated rationale generation in `src/core/pr-rationale.ts` to make `Why` and `Alternatives` sections explicitly evidence-driven for non-fallback scenarios.
+- Replaced generic boilerplate lead bullets with PR-specific context fields (profile/modules/signal evidence from changed files).
+- Preserved deterministic/fallback behavior when changed-file signals are unavailable.

--- a/.vibe/reviews/107/implementation.md
+++ b/.vibe/reviews/107/implementation.md
@@ -3,3 +3,15 @@
 - Updated rationale generation in `src/core/pr-rationale.ts` to make `Why` and `Alternatives` sections explicitly evidence-driven for non-fallback scenarios.
 - Replaced generic boilerplate lead bullets with PR-specific context fields (profile/modules/signal evidence from changed files).
 - Preserved deterministic/fallback behavior when changed-file signals are unavailable.
+
+## Run 2026-03-02T20:33:20.176Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Rationale generation was updated to use concrete per-PR evidence (profile/modules/file sample) in Why/Alternatives, replacing previously generic lead text while preserving deterministic fallback behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/107/ops.md
+++ b/.vibe/reviews/107/ops.md
@@ -3,3 +3,15 @@ Ops/release pass:
 - No dependency or CI workflow changes.
 - Change is localized to rationale text generation and test assertions.
 - Deterministic behavior preserved; verification ran via repo-local commands (`pnpm test`, `pnpm build`).
+
+## Run 2026-03-02T20:33:20.179Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Operational impact is low and contained to rationale text output; no CI/release/dependency workflow regressions were identified.
+
+### Findings
+- none

--- a/.vibe/reviews/107/ops.md
+++ b/.vibe/reviews/107/ops.md
@@ -1,0 +1,5 @@
+## Run 2026-03-02T20:31:32Z
+Ops/release pass:
+- No dependency or CI workflow changes.
+- Change is localized to rationale text generation and test assertions.
+- Deterministic behavior preserved; verification ran via repo-local commands (`pnpm test`, `pnpm build`).

--- a/.vibe/reviews/107/quality.md
+++ b/.vibe/reviews/107/quality.md
@@ -1,0 +1,12 @@
+## Run 2026-03-02T20:31:32Z
+What I tested:
+- Updated `tests/pr-rationale.test.ts` assertions to enforce non-boilerplate behavior in non-fallback contexts.
+- Added expectations that `why`/`alternatives` include concrete evidence/profile references in code-only and deps-only scenarios.
+- Ran full repository test suite and build.
+
+Commands:
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- Live GitHub PR body rendering outside mocked/local test flows.

--- a/.vibe/reviews/107/quality.md
+++ b/.vibe/reviews/107/quality.md
@@ -10,3 +10,15 @@ Commands:
 
 Untested:
 - Live GitHub PR body rendering outside mocked/local test flows.
+
+## Run 2026-03-02T20:33:20.178Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Tests were strengthened to guard against generic rationale phrasing in non-fallback scenarios and to assert evidence/profile inclusion; coverage is aligned with the behavior change.
+
+### Findings
+- none

--- a/.vibe/reviews/107/security.md
+++ b/.vibe/reviews/107/security.md
@@ -1,0 +1,8 @@
+## Run 2026-03-02T20:31:32Z
+Threat model quick scan:
+This change only modifies generated PR-body rationale text. Main risks are accidental inclusion of unsafe/unescaped data in markdown output or overclaiming evidence that was not present in signals.
+
+Checks and mitigations:
+- Content remains deterministic and derived from existing local signals (issue metadata + changed files + validation/review summaries).
+- Fallback lines remain explicit when changed-file signals are unavailable.
+- No new command execution, auth surface, network paths, or secret-handling behavior introduced.

--- a/.vibe/reviews/107/security.md
+++ b/.vibe/reviews/107/security.md
@@ -6,3 +6,15 @@ Checks and mitigations:
 - Content remains deterministic and derived from existing local signals (issue metadata + changed files + validation/review summaries).
 - Fallback lines remain explicit when changed-file signals are unavailable.
 - No new command execution, auth surface, network paths, or secret-handling behavior introduced.
+
+## Run 2026-03-02T20:33:20.177Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No new security risks were introduced by this diff; changes remain in deterministic PR-body text generation and do not expand execution/auth/data exposure surfaces.
+
+### Findings
+- none

--- a/.vibe/reviews/107/ux.md
+++ b/.vibe/reviews/107/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T20:33:20.178Z
+- run_id: issue-107-review-pass-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No user-facing UI surface was changed in this diff; no design-system or accessibility regressions were identified.
+
+### Findings
+- none

--- a/src/core/pr-rationale.ts
+++ b/src/core/pr-rationale.ts
@@ -421,26 +421,39 @@ function buildArchitectureLines(context: RationaleContext, facts: RationaleFacts
 }
 
 function buildWhyLines(context: RationaleContext, facts: RationaleFacts): string[] {
-  const themeText = facts.issueThemes.length ? ` themes=${facts.issueThemes.join(", ")}` : "";
-  const labelText = facts.labels.length ? ` labels=${facts.labels.join(", ")}` : " labels=none";
+  const themeText = facts.issueThemes.length ? facts.issueThemes.join(", ") : "none";
+  const labelText = facts.labels.length ? facts.labels.join(", ") : "none";
+  const moduleText = facts.modules.length ? facts.modules.join(", ") : "none inferred";
+  const sampleText = formatSampleFiles(facts.sampleFiles);
+  const evidenceText = facts.hasChangedFileSignals ? sampleText : "changed-file signals unavailable";
   const lines = [
-    `- Generate reviewer context from issue metadata (\`${context.issueTitle}\`;${themeText || " themes=none"};${labelText}) instead of reusing a boilerplate rationale block.`,
+    `- Tailor this rationale to issue #${context.issueId} (\`${context.issueTitle}\`) on \`${context.branch}\`: profile=\`${facts.profile}\`, modules=[${moduleText}], evidence=${evidenceText}, themes=${themeText}, labels=${labelText}.`,
   ];
 
   if (facts.profile === "docs-only") {
-    lines.push("- A docs-only diff should justify wording/contract clarifications, not claim code-path risk changes that are absent from the touched files.");
+    lines.push(
+      `- This docs-only diff should justify wording/contract clarifications in ${sampleText}, not claim runtime risk changes that are absent from touched files.`,
+    );
   } else if (facts.profile === "deps-only") {
     lines.push(
-      "- A dependency-only diff should explain version/advisory intent (for example vulnerability remediation) rather than implying direct feature implementation.",
+      `- A dependency-only diff should explain version/advisory intent from ${sampleText} rather than implying direct feature implementation.`,
     );
   } else if (facts.profile === "tests-only") {
-    lines.push("- A tests-only diff should explain the regression or edge case being pinned so review effort stays focused on intent and coverage quality.");
+    lines.push(
+      `- A tests-only diff should explain the regression or edge case pinned by ${sampleText} so review effort stays focused on intent and coverage quality.`,
+    );
   } else if (facts.hasCode && facts.hasTests) {
-    lines.push("- Mixed code+tests changes need a rationale that links behavior changes to the test edits in the same PR, which a generic template cannot express.");
+    lines.push(
+      `- Mixed code+tests changes need a rationale that links behavior paths and tests in ${sampleText}; a generic template cannot express this mapping.`,
+    );
   } else if (facts.hasCode) {
-    lines.push("- Code-bearing diffs should mention touched modules and expected blast radius so reviewers can prioritize deeper inspection where it matters.");
+    lines.push(
+      `- Code-bearing diffs should call out touched modules [${moduleText}] and blast radius hinted by ${sampleText} so reviewers can prioritize deeper inspection.`,
+    );
   } else {
-    lines.push(`- \`${context.mode}\` generation stays deterministic even when only partial signals are available, so reruns do not rewrite the PR body arbitrarily.`);
+    lines.push(
+      `- \`${context.mode}\` generation stays deterministic when only partial signals are available, so reruns do not rewrite the PR body arbitrarily.`,
+    );
   }
 
   const validationSummary = summarizeValidationSignals(facts.validationSignals);
@@ -466,22 +479,35 @@ function buildWhyLines(context: RationaleContext, facts: RationaleFacts): string
 }
 
 function buildAlternativesLines(context: RationaleContext, facts: RationaleFacts): string[] {
+  const moduleText = facts.modules.length ? facts.modules.join(", ") : "none inferred";
+  const sampleText = formatSampleFiles(facts.sampleFiles);
+  const evidenceText = facts.hasChangedFileSignals ? sampleText : "changed-file signals unavailable";
   const lines = [
-    "- Keep one fixed rationale bullet set for every PR: rejected because it produces low-signal descriptions across unrelated changes.",
+    `- Reuse one static alternatives section across all PRs: rejected for this diff (profile=\`${facts.profile}\`, modules=[${moduleText}], evidence=${evidenceText}).`,
   ];
 
   if (facts.profile === "docs-only") {
-    lines.push("- Describe docs-only edits as runtime refactors: rejected because no code/test paths appear in the touched-file signal.");
+    lines.push(`- Describe docs-only edits as runtime refactors: rejected because ${sampleText} contains docs paths, not runtime/test paths.`);
   } else if (facts.profile === "deps-only") {
-    lines.push("- Describe dependency-only updates as feature delivery work: rejected because the diff signal is package manifest/lockfile maintenance.");
+    lines.push(
+      `- Describe dependency-only updates as feature delivery work: rejected because ${sampleText} is package/lockfile maintenance.`,
+    );
   } else if (facts.profile === "tests-only") {
-    lines.push("- Present test-only work as a feature implementation: rejected because the diff signal shows verification changes without runtime edits.");
+    lines.push(
+      `- Present test-only work as a feature implementation: rejected because ${sampleText} shows verification changes without runtime edits.`,
+    );
   } else if (facts.hasCode && facts.hasTests) {
-    lines.push("- Split code and tests into unrelated narratives: rejected because reviewers need one cohesive explanation for behavior plus verification.");
+    lines.push(
+      `- Split code and tests into unrelated narratives: rejected because ${sampleText} needs one cohesive behavior+verification explanation.`,
+    );
   } else if (facts.hasCode) {
-    lines.push("- Infer intent from the issue title alone and ignore touched modules: rejected because file-level signals expose the real review surface.");
+    lines.push(
+      `- Infer intent from the issue title alone and ignore touched modules [${moduleText}]: rejected because file-level evidence ${sampleText} exposes the actual review surface.`,
+    );
   } else {
-    lines.push(`- Overfit the rationale to \`${context.mode}\` mode defaults when stronger signals are missing: rejected in favor of explicit fallback text.`);
+    lines.push(
+      `- Overfit the rationale to \`${context.mode}\` mode defaults when stronger signals are missing: rejected in favor of explicit fallback text.`,
+    );
   }
 
   if (facts.hasChangedFileSignals) {

--- a/tests/pr-rationale.test.ts
+++ b/tests/pr-rationale.test.ts
@@ -110,6 +110,11 @@ describe("pr rationale helpers", () => {
     expect(mixed.architecture.join("\n")).toContain("profile=`code+tests`");
     expect(mixed.why.join("\n")).toContain("Mixed code+tests changes");
     expect(cli.why.join("\n")).not.toContain("themes=pr, tracker");
+    expect(cli.why.join("\n")).not.toContain("boilerplate rationale block");
+    expect(cli.alternatives.join("\n")).not.toContain("Keep one fixed rationale bullet set for every PR");
+    expect(cli.why.join("\n")).toContain("profile=`code-only`");
+    expect(cli.alternatives.join("\n")).toContain("profile=`code-only`");
+    expect(cli.why.join("\n")).toContain("evidence=`src/core/pr-open.ts`, `src/core/pr-rationale.ts`");
 
     expect(cli.why.join("\n")).not.toBe(docs.why.join("\n"));
     expect(cli.why.join("\n")).not.toBe(mixed.why.join("\n"));
@@ -235,6 +240,8 @@ describe("pr rationale helpers", () => {
     expect(sections.architecture.join("\n")).not.toContain("documentation-only");
     expect(sections.why.join("\n")).toContain("dependency-only diff");
     expect(sections.alternatives.join("\n")).toContain("dependency-only updates");
+    expect(sections.why.join("\n")).toContain("evidence=`package.json`, `pnpm-lock.yaml`");
+    expect(sections.alternatives.join("\n")).toContain("profile=`deps-only`");
     expect(debug.profile).toBe("deps-only");
     expect(debug.modules).toEqual(expect.arrayContaining(["cli", "deps"]));
     expect(debug.changed_files_count).toBe(2);


### PR DESCRIPTION
## Summary
- Issue: #107 bug(pr): rationale sections remain generic in some PRs
- Branch: `codex/issue-107-rationale-specificity`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/107

## Architecture decisions
- Scope this PR to issue #107 (`bug(pr): rationale sections remain generic in some PRs`) on branch `codex/issue-107-rationale-specificity` in `pr-open` mode.
- Derived from changed files (2): profile=`code+tests`, modules=[cli, pr, tests], sample=`src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Tailor this rationale to issue #107 (`bug(pr): rationale sections remain generic in some PRs`) on `codex/issue-107-rationale-specificity`: profile=`code+tests`, modules=[cli, pr, tests], evidence=`src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`, themes=pr, review, tracker, docs, labels=bug, module:cli, status:backlog.
- Mixed code+tests changes need a rationale that links behavior paths and tests in `src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`; a generic template cannot express this mapping.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Reuse one static alternatives section across all PRs: rejected for this diff (profile=`code+tests`, modules=[cli, pr, tests], evidence=`src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`).
- Split code and tests into unrelated narratives: rejected because `src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts` needs one cohesive behavior+verification explanation.
- Claim evidence not present in the signals (sample `src/core/pr-rationale.ts`, `tests/pr-rationale.test.ts`): rejected to keep rationale deterministic and auditable.

Fixes #107