### PR TITLE
#106 feat(init): make tracker bootstrap opt-in for external repos

### DIFF
--- a/.vibe/reviews/106/growth.md
+++ b/.vibe/reviews/106/growth.md
@@ -2,3 +2,15 @@
 Growth pass:
 - This change reduces onboarding friction in external repos by removing an invalid default path (`dist/cli.cjs`) from generated guidance.
 - Expected impact: fewer false starts and less unnecessary bootstrap work when users only need to run `vibe` commands.
+
+## Run 2026-03-02T20:54:10.193Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+The change likely reduces onboarding friction, but there is still no instrumentation to verify activation impact.
+
+### Findings
+- [P3] No measurable signal for `init` activation vs tracker-bootstrap friction (src/cli-program.ts:1850)

--- a/.vibe/reviews/106/growth.md
+++ b/.vibe/reviews/106/growth.md
@@ -1,0 +1,4 @@
+## Run 2026-03-02T20:50:36Z
+Growth pass:
+- This change reduces onboarding friction in external repos by removing an invalid default path (`dist/cli.cjs`) from generated guidance.
+- Expected impact: fewer false starts and less unnecessary bootstrap work when users only need to run `vibe` commands.

--- a/.vibe/reviews/106/growth.md
+++ b/.vibe/reviews/106/growth.md
@@ -14,3 +14,15 @@ The change likely reduces onboarding friction, but there is still no instrumenta
 
 ### Findings
 - [P3] No measurable signal for `init` activation vs tracker-bootstrap friction (src/cli-program.ts:1850)
+
+## Run 2026-03-02T20:57:28.636Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Onboarding friction for external repos is reduced by removing GH bootstrap from default init path; no regressions identified in this diff.
+
+### Findings
+- none

--- a/.vibe/reviews/106/implementation.md
+++ b/.vibe/reviews/106/implementation.md
@@ -17,3 +17,15 @@ The diff updates managed snippet wording to `vibe` commands, but the core `init`
 
 ### Findings
 - [P1] `init` still performs tracker bootstrap by default instead of opt-in (src/cli-program.ts:1868)
+
+## Run 2026-03-02T20:57:28.634Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+`init` now defaults to scaffold-only and requires explicit opt-in (`--bootstrap-tracker`) for tracker bootstrap; behavior matches issue intent.
+
+### Findings
+- none

--- a/.vibe/reviews/106/implementation.md
+++ b/.vibe/reviews/106/implementation.md
@@ -5,3 +5,15 @@
   - replaced `node dist/cli.cjs postflight`/`--apply` with `vibe postflight`/`--apply`
 - This avoids false assumptions that every target repo has local `dist/cli.cjs`.
 - Updated CLI tests to assert the new snippet contract (`tests/cli-init.test.ts`, `tests/cli-update.test.ts`).
+
+## Run 2026-03-02T20:54:10.191Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+The diff updates managed snippet wording to `vibe` commands, but the core `init` flow still runs tracker bootstrap by default, so the opt-in behavior in issue #106 is not implemented.
+
+### Findings
+- [P1] `init` still performs tracker bootstrap by default instead of opt-in (src/cli-program.ts:1868)

--- a/.vibe/reviews/106/implementation.md
+++ b/.vibe/reviews/106/implementation.md
@@ -1,0 +1,7 @@
+## Run 2026-03-02T20:50:36Z
+- Scope: issue #106 (`feat(init): make tracker bootstrap opt-in for external repos`) - incremental fix for managed snippet command path in external repos.
+- Updated scaffold-managed AGENTS snippet generation in `src/core/init.ts`:
+  - replaced `node dist/cli.cjs preflight` with `vibe preflight`
+  - replaced `node dist/cli.cjs postflight`/`--apply` with `vibe postflight`/`--apply`
+- This avoids false assumptions that every target repo has local `dist/cli.cjs`.
+- Updated CLI tests to assert the new snippet contract (`tests/cli-init.test.ts`, `tests/cli-update.test.ts`).

--- a/.vibe/reviews/106/ops.md
+++ b/.vibe/reviews/106/ops.md
@@ -1,0 +1,5 @@
+## Run 2026-03-02T20:50:36Z
+Ops/release pass:
+- No dependency or CI changes.
+- Change is isolated to scaffold text generation and tests.
+- Validation stayed deterministic with repo-local commands (`pnpm test`, `pnpm build`).

--- a/.vibe/reviews/106/ops.md
+++ b/.vibe/reviews/106/ops.md
@@ -3,3 +3,15 @@ Ops/release pass:
 - No dependency or CI changes.
 - Change is isolated to scaffold text generation and tests.
 - Validation stayed deterministic with repo-local commands (`pnpm test`, `pnpm build`).
+
+## Run 2026-03-02T20:54:10.194Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+Operational reliability is still impacted because default `init` depends on GH operations.
+
+### Findings
+- [P1] `init` remains GH-dependent on the default path (src/cli-program.ts:1868)

--- a/.vibe/reviews/106/ops.md
+++ b/.vibe/reviews/106/ops.md
@@ -15,3 +15,15 @@ Operational reliability is still impacted because default `init` depends on GH o
 
 ### Findings
 - [P1] `init` remains GH-dependent on the default path (src/cli-program.ts:1868)
+
+## Run 2026-03-02T20:57:28.636Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+`init` is now more deterministic in environments without `gh` setup because remote tracker operations are opt-in.
+
+### Findings
+- none

--- a/.vibe/reviews/106/quality.md
+++ b/.vibe/reviews/106/quality.md
@@ -1,0 +1,12 @@
+## Run 2026-03-02T20:50:36Z
+What I tested:
+- Updated tests to verify managed snippet uses `vibe preflight` and `vibe postflight` commands.
+- Ran repository test suite and build.
+
+Commands:
+- `pnpm test -- tests/cli-init.test.ts tests/cli-update.test.ts`
+- `pnpm test`
+- `pnpm build`
+
+Untested:
+- Manual execution in an external repo during this pass (recommended as follow-up smoke check).

--- a/.vibe/reviews/106/quality.md
+++ b/.vibe/reviews/106/quality.md
@@ -22,3 +22,15 @@ Tests were updated for snippet text, but coverage does not validate the intended
 
 ### Findings
 - [P2] Missing regression test for default no-bootstrap `init` behavior (tests/cli-init.test.ts:66)
+
+## Run 2026-03-02T20:57:28.635Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Regression coverage now validates default no-bootstrap behavior, explicit bootstrap path, flag-conflict handling, and updated preflight command hints.
+
+### Findings
+- none

--- a/.vibe/reviews/106/quality.md
+++ b/.vibe/reviews/106/quality.md
@@ -10,3 +10,15 @@ Commands:
 
 Untested:
 - Manual execution in an external repo during this pass (recommended as follow-up smoke check).
+
+## Run 2026-03-02T20:54:10.193Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+Tests were updated for snippet text, but coverage does not validate the intended opt-in bootstrap contract.
+
+### Findings
+- [P2] Missing regression test for default no-bootstrap `init` behavior (tests/cli-init.test.ts:66)

--- a/.vibe/reviews/106/security.md
+++ b/.vibe/reviews/106/security.md
@@ -1,0 +1,8 @@
+## Run 2026-03-02T20:50:36Z
+Threat model quick scan:
+The change only modifies scaffolded instruction text in AGENTS managed blocks. Main risk is operator confusion leading to incorrect command execution paths in external repos.
+
+Checks and mitigations:
+- Replacing `node dist/cli.cjs` with `vibe` reduces command-path coupling to this repository internals.
+- No new command execution surface, network behavior, or secret handling was introduced.
+- Existing marker-safe scaffold update semantics remain unchanged.

--- a/.vibe/reviews/106/security.md
+++ b/.vibe/reviews/106/security.md
@@ -18,3 +18,15 @@ No new direct vulnerability was introduced by the text changes, but default writ
 
 ### Findings
 - [P2] Default `init` path can mutate GitHub tracker state without explicit consent (src/cli-program.ts:1853)
+
+## Run 2026-03-02T20:57:28.634Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Default path no longer performs unintended GitHub mutations, reducing accidental write risk and privilege exposure.
+
+### Findings
+- none

--- a/.vibe/reviews/106/security.md
+++ b/.vibe/reviews/106/security.md
@@ -6,3 +6,15 @@ Checks and mitigations:
 - Replacing `node dist/cli.cjs` with `vibe` reduces command-path coupling to this repository internals.
 - No new command execution surface, network behavior, or secret handling was introduced.
 - Existing marker-safe scaffold update semantics remain unchanged.
+
+## Run 2026-03-02T20:54:10.192Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+No new direct vulnerability was introduced by the text changes, but default write behavior on `init` still violates least-privilege expectations for external repos.
+
+### Findings
+- [P2] Default `init` path can mutate GitHub tracker state without explicit consent (src/cli-program.ts:1853)

--- a/.vibe/reviews/106/ux.md
+++ b/.vibe/reviews/106/ux.md
@@ -23,3 +23,15 @@ CLI copy improved in scaffolded AGENTS, but command guidance remains inconsisten
 
 ### Findings
 - [P2] Preflight hint still points to `node dist/cli.cjs` while scaffolded docs use `vibe` (src/cli-program.ts:2350)
+
+## Run 2026-03-02T20:57:28.635Z
+- run_id: pr-109-issue-106-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+CLI command language is now consistent (`vibe ...`) across scaffolded guidance and preflight hints.
+
+### Findings
+- none

--- a/.vibe/reviews/106/ux.md
+++ b/.vibe/reviews/106/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-02T20:54:10.193Z
+- run_id: pr-109-issue-106-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+CLI copy improved in scaffolded AGENTS, but command guidance remains inconsistent across surfaces.
+
+### Findings
+- [P2] Preflight hint still points to `node dist/cli.cjs` while scaffolded docs use `vibe` (src/cli-program.ts:2350)

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ vibe preflight
 vibe postflight --apply --dry-run
 ```
 
-If `gh` is unavailable in the target repo, run:
+`init` now skips tracker bootstrap by default. If you want to create tracker taxonomy immediately, run:
 
 ```bash
-vibe init --skip-tracker
+vibe init --bootstrap-tracker
 ```
 
 For phased sharing (pilot -> beta -> social) and copy/paste launch messages, see [SHARE.md](./SHARE.md).
@@ -99,7 +99,9 @@ cd /path/to/another-repo
 # one-time setup for agent-first workflow
 vibe init --dry-run
 vibe init
-# if gh is unavailable, scaffold local files only
+# optional: create tracker labels/milestones immediately
+# vibe init --bootstrap-tracker
+# compatibility alias (same default behavior):
 # vibe init --skip-tracker
 
 # now these commands are valid
@@ -149,6 +151,7 @@ vibe postflight --apply
 `preflight` now prints a security snapshot (policy, gitleaks availability, last scan), a hint when `.vibe` exists but tracker bootstrap marker is missing, and read-only semantic milestone suggestions for issues without milestone.
 `preflight` also performs a best-effort, non-blocking tool version check and prints an explicit `self update` command when a newer `vibe-backlog` release is available.
 `update` checks/applies `.vibe` scaffold updates with metadata tracking in `.vibe/scaffold.json`, dry-run diff preview, and marker-safe preservation of protected sections.
+`init` scaffolds local `.vibe` files and skips tracker bootstrap by default; use `--bootstrap-tracker` to opt in tracker GH operations during init.
 `init`/`update` also scaffold a managed README workflow section (`<!-- vibe:workflow-docs:start --> ... <!-- vibe:workflow-docs:end -->`) with a Mermaid diagram, preserving non-managed README content.
 `update --json` includes `readme_workflow_status` with one of: `created` (workflow block created, including first insertion into an existing README), `updated` (existing managed block refreshed), `unchanged` (already up-to-date), `repaired` (malformed markers were repaired).
 `status` shows active turn, in-progress issues, hygiene warnings, and branch PR snapshot.
@@ -229,6 +232,7 @@ node dist/cli.cjs pr ready --pr <n> --wait-seconds 30
 node dist/cli.cjs pr ready --branch <name> --refresh --wait-seconds 30
 node dist/cli.cjs init --dry-run
 node dist/cli.cjs init
+node dist/cli.cjs init --bootstrap-tracker
 node dist/cli.cjs tracker bootstrap --dry-run
 node dist/cli.cjs tracker bootstrap
 node dist/cli.cjs tracker reconcile --dry-run

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -1850,10 +1850,18 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
     .command("init")
     .description("Initialize agent-first .vibe scaffolding in current repository")
     .option("--dry-run", "Print planned changes without writing files", false)
-    .option("--skip-tracker", "Skip tracker bootstrap gh operations", false)
+    .option("--bootstrap-tracker", "Run tracker bootstrap gh operations", false)
+    .option("--skip-tracker", "Compatibility alias for no tracker bootstrap (default behavior)", false)
     .action(async (opts) => {
       const dryRun = Boolean(opts.dryRun);
+      const bootstrapTracker = Boolean(opts.bootstrapTracker);
       const skipTracker = Boolean(opts.skipTracker);
+
+      if (bootstrapTracker && skipTracker) {
+        console.error("init: use either --bootstrap-tracker or --skip-tracker, not both.");
+        process.exitCode = 1;
+        return;
+      }
 
       try {
         console.log(`init: ${dryRun ? "dry-run" : "apply"} mode`);
@@ -1865,11 +1873,14 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         printPathList("Created", scaffoldResult.created);
         printPathList("Updated", scaffoldResult.updated);
 
-        if (!skipTracker) {
+        if (bootstrapTracker) {
           console.log("\ninit: tracker bootstrap");
           await runTrackerBootstrap(execaFn, dryRun);
         } else {
-          console.log("\ninit: tracker bootstrap skipped (--skip-tracker).");
+          const reason = skipTracker ? "--skip-tracker" : "default";
+          console.log(`\ninit: tracker bootstrap skipped (${reason}).`);
+          console.log("Run later (optional): vibe tracker bootstrap --dry-run");
+          console.log("Then: vibe tracker bootstrap");
         }
 
         if (dryRun) {
@@ -2347,8 +2358,8 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         if (shouldHint) {
           console.log("\nTracker bootstrap suggested:");
           console.log("Detected .vibe without tracker taxonomy marker.");
-          console.log("Run: node dist/cli.cjs tracker bootstrap --dry-run");
-          console.log("Then: node dist/cli.cjs tracker bootstrap");
+          console.log("Run: vibe tracker bootstrap --dry-run");
+          console.log("Then: vibe tracker bootstrap");
         }
       } catch {
         // Ignore hint failures: preflight must remain resilient.

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -170,10 +170,10 @@ function buildScaffoldMetadataJson(identity: ToolIdentity): string {
 function buildAgentSnippetBlock(): string {
   const body = [
     "## Vibe Agent Workflow (Managed)",
-    "- Run `node dist/cli.cjs preflight` before implementation.",
+    "- Run `vibe preflight` before implementation.",
     "- Use one issue per topic and keep tracker labels updated.",
     "- Use semantic, repo-specific milestones (avoid fixed milestone catalogs).",
-    "- Validate with `node dist/cli.cjs postflight` and apply updates with `node dist/cli.cjs postflight --apply`.",
+    "- Validate with `vibe postflight` and apply updates with `vibe postflight --apply`.",
   ].join("\n");
 
   return `${AGENT_SNIPPET_START}\n${body}\n${AGENT_SNIPPET_END}\n`;

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -28,19 +28,8 @@ describe.sequential("cli init", () => {
     }
   });
 
-  it("initializes empty repo scaffold and runs tracker bootstrap", async () => {
-    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
-      if (args[0] === "repo" && args[1] === "view") {
-        return { stdout: "acme/demo\n" };
-      }
-      if (args[0] === "api" && args[1] === "repos/acme/demo/milestones?state=all&per_page=100&page=1") {
-        return { stdout: "[]" };
-      }
-      if (args[0] === "api" && args[1] === "repos/acme/demo/labels?per_page=100&page=1") {
-        return { stdout: "[]" };
-      }
-      return { stdout: "" };
-    });
+  it("initializes empty repo scaffold without tracker bootstrap by default", async () => {
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
 
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -63,6 +52,31 @@ describe.sequential("cli init", () => {
     expect(readFileSync(path.join(tempDir, "README.md"), "utf8")).toContain("```mermaid");
     expect(readFileSync(path.join(tempDir, "README.md"), "utf8")).toContain("Workflow steps (text fallback):");
     expect(readFileSync(path.join(tempDir, ".gitignore"), "utf8")).toContain(".vibe/runtime");
+    expect(existsSync(getTrackerBootstrapMarkerPath())).toBe(false);
+    expect(execaMock).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("runs tracker bootstrap when init receives --bootstrap-tracker", async () => {
+    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
+      if (args[0] === "repo" && args[1] === "view") {
+        return { stdout: "acme/demo\n" };
+      }
+      if (args[0] === "api" && args[1] === "repos/acme/demo/milestones?state=all&per_page=100&page=1") {
+        return { stdout: "[]" };
+      }
+      if (args[0] === "api" && args[1] === "repos/acme/demo/labels?per_page=100&page=1") {
+        return { stdout: "[]" };
+      }
+      return { stdout: "" };
+    });
+
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--bootstrap-tracker"]);
+
     expect(existsSync(getTrackerBootstrapMarkerPath())).toBe(true);
 
     const commands = execaMock.mock.calls.map((call) => [call[0], call[1]] as [string, string[]]);
@@ -120,10 +134,26 @@ describe.sequential("cli init", () => {
     vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const program = createProgram(execaMock as never);
-    await program.parseAsync(["node", "vibe", "init", "--dry-run", "--skip-tracker"]);
+    await program.parseAsync(["node", "vibe", "init", "--dry-run"]);
 
     expect(existsSync(path.join(tempDir, ".vibe"))).toBe(false);
     expect(existsSync(path.join(tempDir, "AGENTS.md"))).toBe(false);
     expect(existsSync(path.join(tempDir, ".gitignore"))).toBe(false);
+  });
+
+  it("fails when init receives both --bootstrap-tracker and --skip-tracker", async () => {
+    const errors: string[] = [];
+    const execaMock = vi.fn(async () => ({ stdout: "" }));
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errors.push(args.map((arg) => String(arg)).join(" "));
+    });
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "init", "--bootstrap-tracker", "--skip-tracker"]);
+
+    expect(process.exitCode).toBe(1);
+    expect(errors.some((line) => line.includes("use either --bootstrap-tracker or --skip-tracker"))).toBe(true);
+    expect(execaMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/cli-init.test.ts
+++ b/tests/cli-init.test.ts
@@ -54,7 +54,10 @@ describe.sequential("cli init", () => {
     expect(readFileSync(path.join(tempDir, ".vibe", "contract.yml"), "utf8")).toContain("gitleaks:");
     expect(readFileSync(path.join(tempDir, ".vibe", "contract.yml"), "utf8")).toContain("policy: warn");
     expect(existsSync(path.join(tempDir, "AGENTS.md"))).toBe(true);
-    expect(readFileSync(path.join(tempDir, "AGENTS.md"), "utf8")).toContain("<!-- vibe:agent-snippet:start -->");
+    const agents = readFileSync(path.join(tempDir, "AGENTS.md"), "utf8");
+    expect(agents).toContain("<!-- vibe:agent-snippet:start -->");
+    expect(agents).toContain("Run `vibe preflight` before implementation.");
+    expect(agents).toContain("Validate with `vibe postflight` and apply updates with `vibe postflight --apply`.");
     expect(existsSync(path.join(tempDir, "README.md"))).toBe(true);
     expect(readFileSync(path.join(tempDir, "README.md"), "utf8")).toContain("<!-- vibe:workflow-docs:start -->");
     expect(readFileSync(path.join(tempDir, "README.md"), "utf8")).toContain("```mermaid");

--- a/tests/cli-tracker.test.ts
+++ b/tests/cli-tracker.test.ts
@@ -257,8 +257,8 @@ describe.sequential("cli tracker bootstrap", () => {
     await program.parseAsync(["node", "vibe", "preflight"]);
 
     expect(logs.some((line) => line.includes("Tracker bootstrap suggested:"))).toBe(true);
-    expect(logs.some((line) => line.includes("Run: node dist/cli.cjs tracker bootstrap --dry-run"))).toBe(true);
-    expect(logs.some((line) => line.includes("Then: node dist/cli.cjs tracker bootstrap"))).toBe(true);
+    expect(logs.some((line) => line.includes("Run: vibe tracker bootstrap --dry-run"))).toBe(true);
+    expect(logs.some((line) => line.includes("Then: vibe tracker bootstrap"))).toBe(true);
   });
 });
 

--- a/tests/cli-update.test.ts
+++ b/tests/cli-update.test.ts
@@ -203,7 +203,8 @@ describe.sequential("cli update flows", () => {
     const agentsAfterApply = readFileSync(agentsPath, "utf8");
     const readmeAfterApply = readFileSync(readmePath, "utf8");
     expect(agentsAfterApply).toContain("keep-my-note");
-    expect(agentsAfterApply).toContain("Run `node dist/cli.cjs preflight` before implementation.");
+    expect(agentsAfterApply).toContain("Run `vibe preflight` before implementation.");
+    expect(agentsAfterApply).toContain("Validate with `vibe postflight` and apply updates with `vibe postflight --apply`.");
     expect(agentsAfterApply).not.toContain("old managed snippet body");
     expect(readmeAfterApply).toContain("# Demo repo");
     expect(readmeAfterApply).toContain("Manual intro.");


### PR DESCRIPTION
## Summary
- Issue: #106 feat(init): make tracker bootstrap opt-in for external repos
- Branch: `codex/issue-106-init-managed-snippet-uses-vibe`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/106

## Architecture decisions
- Scope this PR to issue #106 (`feat(init): make tracker bootstrap opt-in for external repos`) on branch `codex/issue-106-init-managed-snippet-uses-vibe` in `pr-open` mode.
- Derived from changed files (3): profile=`code+tests`, modules=[cli, tests, tracker], sample=`src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Tailor this rationale to issue #106 (`feat(init): make tracker bootstrap opt-in for external repos`) on `codex/issue-106-init-managed-snippet-uses-vibe`: profile=`code+tests`, modules=[cli, tests, tracker], evidence=`src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts`, themes=tracker, docs, labels=enhancement, module:tracker, status:backlog.
- Mixed code+tests changes need a rationale that links behavior paths and tests in `src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts`; a generic template cannot express this mapping.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Reuse one static alternatives section across all PRs: rejected for this diff (profile=`code+tests`, modules=[cli, tests, tracker], evidence=`src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts`).
- Split code and tests into unrelated narratives: rejected because `src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts` needs one cohesive behavior+verification explanation.
- Claim evidence not present in the signals (sample `src/core/init.ts`, `tests/cli-init.test.ts`, `tests/cli-update.test.ts`): rejected to keep rationale deterministic and auditable.

Fixes #106