### PR TITLE
#112 feat(postflight): auto-open PR on --apply when branch has no open PR

### DIFF
--- a/.vibe/reviews/112/growth.md
+++ b/.vibe/reviews/112/growth.md
@@ -1,0 +1,25 @@
+# Growth Pass
+
+## Review Focus
+- Funnel stage(s) touched:
+- Instrumentation/experiment impact:
+
+## Checklist
+- [ ] Activation/retention/conversion opportunities reviewed
+- [ ] Measurement gaps and hypotheses captured
+- [ ] Next growth actions are concrete and testable
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.780Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 product-growth opportunity found around visibility of auto-created PRs.
+
+### Findings
+- [P3] Auto-created PRs are not surfaced back into tracker feedback loops (src/cli-program.ts:722)

--- a/.vibe/reviews/112/growth.md
+++ b/.vibe/reviews/112/growth.md
@@ -23,3 +23,15 @@
 
 ### Findings
 - [P3] Auto-created PRs are not surfaced back into tracker feedback loops (src/cli-program.ts:722)
+
+## Run 2026-03-03T17:55:40.860Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No additional growth blockers found after adding auto-linked PR feedback into tracker comments.
+
+### Findings
+- none

--- a/.vibe/reviews/112/implementation.md
+++ b/.vibe/reviews/112/implementation.md
@@ -23,3 +23,15 @@
 
 ### Findings
 - [P1] `postflight --apply` can fail hard when branch equals base branch (src/cli-program.ts:724)
+
+## Run 2026-03-03T17:55:40.859Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No implementation defects or regressions identified in the current diff.
+
+### Findings
+- none

--- a/.vibe/reviews/112/implementation.md
+++ b/.vibe/reviews/112/implementation.md
@@ -1,0 +1,25 @@
+# Implementation Pass
+
+## Scope
+- Issue:
+- Goal:
+
+## Checklist
+- [ ] Diff kept focused to issue scope
+- [ ] Behavior changes documented
+- [ ] Follow-up work listed (if any)
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.778Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+1 regression found in the new auto-PR ensure flow.
+
+### Findings
+- [P1] `postflight --apply` can fail hard when branch equals base branch (src/cli-program.ts:724)

--- a/.vibe/reviews/112/ops.md
+++ b/.vibe/reviews/112/ops.md
@@ -1,0 +1,25 @@
+# Ops Pass
+
+## Release Readiness
+- Commands run:
+- Operational risks:
+
+## Checklist
+- [ ] Build/test reproducibility validated
+- [ ] Rollback strategy noted
+- [ ] CI/deploy impact reviewed
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.780Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No CI/release-process breakage found beyond the implementation regression noted above.
+
+### Findings
+- none

--- a/.vibe/reviews/112/ops.md
+++ b/.vibe/reviews/112/ops.md
@@ -23,3 +23,15 @@ No CI/release-process breakage found beyond the implementation regression noted 
 
 ### Findings
 - none
+
+## Run 2026-03-03T17:55:40.861Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No operational or release-process issues identified; build/test behavior remains stable.
+
+### Findings
+- none

--- a/.vibe/reviews/112/quality.md
+++ b/.vibe/reviews/112/quality.md
@@ -1,0 +1,25 @@
+# Quality Pass
+
+## What I Tested
+- Commands:
+- Scenarios:
+
+## Checklist
+- [ ] Happy path validated
+- [ ] Failure/edge path validated
+- [ ] Remaining gaps captured
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.779Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 1
+- autofix_applied: no
+
+### Summary
+Coverage improved, but key edge-case tests are missing for the new option/branch behavior.
+
+### Findings
+- [P2] No regression tests for same-branch and `--no-ensure-pr` paths (tests/cli-postflight.test.ts:27)

--- a/.vibe/reviews/112/quality.md
+++ b/.vibe/reviews/112/quality.md
@@ -23,3 +23,15 @@ Coverage improved, but key edge-case tests are missing for the new option/branch
 
 ### Findings
 - [P2] No regression tests for same-branch and `--no-ensure-pr` paths (tests/cli-postflight.test.ts:27)
+
+## Run 2026-03-03T17:55:40.860Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+Quality coverage is adequate for this change, including new edge-path tests for same-branch and `--no-ensure-pr` behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/112/security.md
+++ b/.vibe/reviews/112/security.md
@@ -23,3 +23,15 @@ No security regressions identified in the changed behavior.
 
 ### Findings
 - none
+
+## Run 2026-03-03T17:55:40.859Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No security-impacting issues identified in the changed behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/112/security.md
+++ b/.vibe/reviews/112/security.md
@@ -1,0 +1,25 @@
+# Security Pass
+
+## Threat Scan
+- Risks considered:
+- Mitigations applied:
+
+## Checklist
+- [ ] Input validation paths reviewed
+- [ ] Authorization/data exposure reviewed
+- [ ] Error handling avoids sensitive leakage
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.779Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+No security regressions identified in the changed behavior.
+
+### Findings
+- none

--- a/.vibe/reviews/112/ux.md
+++ b/.vibe/reviews/112/ux.md
@@ -23,3 +23,15 @@ CLI-only change; no visual/design-system surface was modified.
 
 ### Findings
 - none
+
+## Run 2026-03-03T17:55:40.860Z
+- run_id: issue-112-attempt-1-rerun
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+CLI-only scope; no UI/UX or design-system findings for this diff.
+
+### Findings
+- none

--- a/.vibe/reviews/112/ux.md
+++ b/.vibe/reviews/112/ux.md
@@ -1,0 +1,25 @@
+# UX Pass
+
+## Review Focus
+- Flow touched:
+- Accessibility/performance checks:
+
+## Checklist
+- [ ] Empty and error states reviewed
+- [ ] Copy and affordances reviewed
+- [ ] Interaction quality reviewed
+
+## Notes
+- 
+
+## Run 2026-03-03T17:52:17.780Z
+- run_id: issue-112-attempt-1
+- attempt: 1/5
+- findings: 0
+- autofix_applied: no
+
+### Summary
+CLI-only change; no visual/design-system surface was modified.
+
+### Findings
+- none

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -672,6 +672,7 @@ async function enforcePostflightApplyReviewGate(params: {
   issueId: string;
   branch: string;
   dryRun: boolean;
+  prNumber?: number | null;
 }): Promise<void> {
   const { execaFn, issueId, branch, dryRun } = params;
   if (dryRun) return;
@@ -679,7 +680,8 @@ async function enforcePostflightApplyReviewGate(params: {
   const normalizedBranch = branch.trim();
   if (!normalizedBranch) return;
 
-  const prNumber = await findOpenPullRequestNumberByBranch(execaFn, normalizedBranch);
+  const hasExplicitPrNumber = Object.prototype.hasOwnProperty.call(params, "prNumber");
+  const prNumber = hasExplicitPrNumber ? (params.prNumber ?? null) : await findOpenPullRequestNumberByBranch(execaFn, normalizedBranch);
   if (!prNumber) return;
 
   const repo = await resolveRepoNameWithOwner(execaFn);
@@ -691,6 +693,49 @@ async function enforcePostflightApplyReviewGate(params: {
   throw new Error(
     `postflight --apply: review gate missing for branch '${normalizedBranch}' HEAD ${shortHead} on PR #${prNumber}. Run: node dist/cli.cjs review --issue ${issueId}`,
   );
+}
+
+async function ensurePostflightApplyPullRequest(params: {
+  execaFn: ExecaFn;
+  issueId: string;
+  branch: string;
+  baseBranch: string;
+  dryRun: boolean;
+  ensurePr: boolean;
+}): Promise<{ openPrBefore: number | null }> {
+  const { execaFn, issueId, branch, baseBranch, dryRun, ensurePr } = params;
+  if (dryRun) {
+    return { openPrBefore: null };
+  }
+
+  const normalizedBranch = branch.trim();
+  if (!normalizedBranch) {
+    return { openPrBefore: null };
+  }
+
+  const openPrBefore = await findOpenPullRequestNumberByBranch(execaFn, normalizedBranch);
+  if (openPrBefore || !ensurePr) {
+    return { openPrBefore };
+  }
+
+  const normalizedBaseBranch = baseBranch.trim() || "main";
+  const args = [
+    "pr",
+    "create",
+    "--base",
+    normalizedBaseBranch,
+    "--head",
+    normalizedBranch,
+    "--title",
+    `#${issueId} postflight apply`,
+    "--body",
+    `Fixes #${issueId}`,
+  ];
+  console.log(`postflight --apply: no open PR for branch '${normalizedBranch}'. Auto-creating one.`);
+  printGhCommand(args);
+  await runGhWithRetry(execaFn, args, { stdio: "inherit" });
+
+  return { openPrBefore: null };
 }
 
 async function resolveCurrentBranchName(execaFn: ExecaFn): Promise<string> {
@@ -2378,6 +2423,7 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
     .option("-f, --file <path>", "Path to postflight JSON", ".vibe/artifacts/postflight.json")
     .option("--apply", "Apply tracker updates using gh", false)
     .option("--dry-run", "Print gh commands without executing them", false)
+    .option("--no-ensure-pr", "Skip automatic PR ensure before applying tracker updates")
     .option("--skip-branch-cleanup", "Skip automatic local branch cleanup routine", false)
     .action(async (opts) => {
       const fs = await import("node:fs/promises");
@@ -2428,11 +2474,21 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
           return;
         }
 
+        const prEnsure = await ensurePostflightApplyPullRequest({
+          execaFn,
+          issueId,
+          branch: parsed.data.work.branch,
+          baseBranch: parsed.data.work.base_branch,
+          dryRun: Boolean(opts.dryRun),
+          ensurePr: Boolean(opts.ensurePr),
+        });
+
         await enforcePostflightApplyReviewGate({
           execaFn,
           issueId,
           branch: parsed.data.work.branch,
           dryRun: Boolean(opts.dryRun),
+          prNumber: prEnsure.openPrBefore,
         });
 
         const updates = parsed.data.tracker_updates ?? [];

--- a/src/cli-program.ts
+++ b/src/cli-program.ts
@@ -345,6 +345,19 @@ function parsePositiveInt(value: unknown): number | null {
   return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }
 
+function extractUrl(value: string): string | null {
+  const match = /https?:\/\/\S+/.exec(value);
+  return match?.[0] ? match[0].trim() : null;
+}
+
+function extractPrNumberFromUrl(url: string | null): number | null {
+  if (!url) return null;
+  const match = /\/pull\/(\d+)(?:\/|$)/.exec(url);
+  if (!match?.[1]) return null;
+  const parsed = Number(match[1]);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
 function parsePortNumber(value: unknown): number | null {
   if (typeof value === "number") {
     if (!Number.isInteger(value)) return null;
@@ -702,23 +715,28 @@ async function ensurePostflightApplyPullRequest(params: {
   baseBranch: string;
   dryRun: boolean;
   ensurePr: boolean;
-}): Promise<{ openPrBefore: number | null }> {
+}): Promise<{ openPrBefore: number | null; createdPrNumber: number | null }> {
   const { execaFn, issueId, branch, baseBranch, dryRun, ensurePr } = params;
   if (dryRun) {
-    return { openPrBefore: null };
+    return { openPrBefore: null, createdPrNumber: null };
   }
 
   const normalizedBranch = branch.trim();
   if (!normalizedBranch) {
-    return { openPrBefore: null };
+    return { openPrBefore: null, createdPrNumber: null };
   }
 
   const openPrBefore = await findOpenPullRequestNumberByBranch(execaFn, normalizedBranch);
   if (openPrBefore || !ensurePr) {
-    return { openPrBefore };
+    return { openPrBefore, createdPrNumber: null };
   }
 
   const normalizedBaseBranch = baseBranch.trim() || "main";
+  if (normalizedBranch === normalizedBaseBranch) {
+    console.log(`postflight --apply: skip auto-create PR because branch '${normalizedBranch}' equals base '${normalizedBaseBranch}'.`);
+    return { openPrBefore: null, createdPrNumber: null };
+  }
+
   const args = [
     "pr",
     "create",
@@ -733,9 +751,16 @@ async function ensurePostflightApplyPullRequest(params: {
   ];
   console.log(`postflight --apply: no open PR for branch '${normalizedBranch}'. Auto-creating one.`);
   printGhCommand(args);
-  await runGhWithRetry(execaFn, args, { stdio: "inherit" });
+  const created = await runGhWithRetry(execaFn, args, { stdio: "pipe" });
+  const createdUrl = extractUrl(created.stdout);
+  const createdPrNumber = extractPrNumberFromUrl(createdUrl);
+  if (createdPrNumber && createdUrl) {
+    console.log(`postflight --apply: auto-created PR #${createdPrNumber} ${createdUrl}`);
+  } else if (createdUrl) {
+    console.log(`postflight --apply: auto-created PR ${createdUrl}`);
+  }
 
-  return { openPrBefore: null };
+  return { openPrBefore: null, createdPrNumber };
 }
 
 async function resolveCurrentBranchName(execaFn: ExecaFn): Promise<string> {
@@ -2494,6 +2519,13 @@ export function createProgram(execaFn: ExecaFn = execa): Command {
         const updates = parsed.data.tracker_updates ?? [];
         const cmds = buildTrackerCommands(issueId, updates);
         const linkedPrNumbers = collectLinkedPrNumbers(updates);
+        if (prEnsure.createdPrNumber && !linkedPrNumbers.includes(prEnsure.createdPrNumber)) {
+          linkedPrNumbers.push(prEnsure.createdPrNumber);
+          cmds.unshift({
+            cmd: "gh",
+            args: ["issue", "comment", issueId, "--body", `Linked PR: #${prEnsure.createdPrNumber}`],
+          });
+        }
 
         if (!cmds.length && !linkedPrNumbers.length) {
           console.log("postflight --apply: no hay tracker_updates aplicables.");

--- a/tests/cli-postflight.test.ts
+++ b/tests/cli-postflight.test.ts
@@ -75,7 +75,7 @@ describe.sequential("cli postflight --apply", () => {
     const program = createProgram(execaMock as never);
     await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--skip-branch-cleanup"]);
 
-    expect(execaMock).toHaveBeenCalledTimes(3);
+    expect(execaMock).toHaveBeenCalledTimes(4);
     expect(execaMock).toHaveBeenNthCalledWith(
       1,
       "gh",
@@ -85,11 +85,28 @@ describe.sequential("cli postflight --apply", () => {
     expect(execaMock).toHaveBeenNthCalledWith(
       2,
       "gh",
-      ["issue", "comment", "2", "--body", "Done."],
+      [
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "issue-2-example",
+        "--title",
+        "#2 postflight apply",
+        "--body",
+        "Fixes #2",
+      ],
       { stdio: "inherit" },
     );
     expect(execaMock).toHaveBeenNthCalledWith(
       3,
+      "gh",
+      ["issue", "comment", "2", "--body", "Done."],
+      { stdio: "inherit" },
+    );
+    expect(execaMock).toHaveBeenNthCalledWith(
+      4,
       "gh",
       ["issue", "close", "2", "--comment", "Closed by postflight."],
       { stdio: "inherit" },
@@ -195,7 +212,7 @@ describe.sequential("cli postflight --apply", () => {
     const program = createProgram(execaMock as never);
     await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--skip-branch-cleanup"]);
 
-    expect(execaMock).toHaveBeenCalledTimes(4);
+    expect(execaMock).toHaveBeenCalledTimes(5);
     expect(execaMock).toHaveBeenNthCalledWith(
       1,
       "gh",
@@ -205,12 +222,34 @@ describe.sequential("cli postflight --apply", () => {
     expect(execaMock).toHaveBeenNthCalledWith(
       2,
       "gh",
+      [
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "issue-2-example",
+        "--title",
+        "#2 postflight apply",
+        "--body",
+        "Fixes #2",
+      ],
+      { stdio: "inherit" },
+    );
+    expect(execaMock).toHaveBeenNthCalledWith(
+      3,
+      "gh",
       ["issue", "comment", "2", "--body", "Linked PR: #7"],
       { stdio: "inherit" },
     );
-    expect(execaMock).toHaveBeenNthCalledWith(3, "gh", ["pr", "view", "7", "--json", "body,url"], { stdio: "pipe" });
     expect(execaMock).toHaveBeenNthCalledWith(
       4,
+      "gh",
+      ["pr", "view", "7", "--json", "body,url"],
+      { stdio: "pipe" },
+    );
+    expect(execaMock).toHaveBeenNthCalledWith(
+      5,
       "gh",
       ["pr", "edit", "7", "--body", "Implement turn context\n\nFixes #2"],
       { stdio: "inherit" },
@@ -269,7 +308,7 @@ describe.sequential("cli postflight --apply", () => {
     const program = createProgram(execaMock as never);
     await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--skip-branch-cleanup"]);
 
-    expect(execaMock).toHaveBeenCalledTimes(3);
+    expect(execaMock).toHaveBeenCalledTimes(4);
     expect(execaMock).toHaveBeenNthCalledWith(
       1,
       "gh",
@@ -279,10 +318,27 @@ describe.sequential("cli postflight --apply", () => {
     expect(execaMock).toHaveBeenNthCalledWith(
       2,
       "gh",
+      [
+        "pr",
+        "create",
+        "--base",
+        "main",
+        "--head",
+        "issue-2-example",
+        "--title",
+        "#2 postflight apply",
+        "--body",
+        "Fixes #2",
+      ],
+      { stdio: "inherit" },
+    );
+    expect(execaMock).toHaveBeenNthCalledWith(
+      3,
+      "gh",
       ["issue", "comment", "2", "--body", "Linked PR: #7"],
       { stdio: "inherit" },
     );
-    expect(execaMock).toHaveBeenNthCalledWith(3, "gh", ["pr", "view", "7", "--json", "body,url"], { stdio: "pipe" });
+    expect(execaMock).toHaveBeenNthCalledWith(4, "gh", ["pr", "view", "7", "--json", "body,url"], { stdio: "pipe" });
     expect(process.exitCode).toBeUndefined();
   });
 

--- a/tests/cli-postflight.test.ts
+++ b/tests/cli-postflight.test.ts
@@ -97,7 +97,7 @@ describe.sequential("cli postflight --apply", () => {
         "--body",
         "Fixes #2",
       ],
-      { stdio: "inherit" },
+      { stdio: "pipe" },
     );
     expect(execaMock).toHaveBeenNthCalledWith(
       3,
@@ -112,6 +112,184 @@ describe.sequential("cli postflight --apply", () => {
       { stdio: "inherit" },
     );
     expect(process.exitCode).toBeUndefined();
+  });
+
+  it("records auto-created PR back into tracker comments when PR URL is returned", async () => {
+    const postflightPath = path.join(tempDir, "auto-pr-link-postflight.json");
+    writeFileSync(
+      postflightPath,
+      JSON.stringify(
+        {
+          version: 1,
+          meta: {
+            timestamp: "2026-02-13T00:00:00.000Z",
+            actor: "agent",
+            mode: "cli",
+          },
+          work: {
+            issue_id: 2,
+            branch: "issue-2-example",
+            base_branch: "main",
+          },
+          checks: {
+            tests: {
+              ran: true,
+              result: "pass",
+            },
+          },
+          tracker_updates: [{ type: "comment_append", body: "Done." }],
+          next_actions: ["Merge branch."],
+          risks: {
+            summary: "Low risk.",
+            rollback_plan: "Revert commit.",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
+      if (args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]" };
+      }
+      if (args[0] === "pr" && args[1] === "create") {
+        return { stdout: "https://example.test/pull/77\n" };
+      }
+      return { stdout: "" };
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--skip-branch-cleanup"]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(
+      execaMock.mock.calls.some(
+        ([cmd, args]) =>
+          cmd === "gh" &&
+          Array.isArray(args) &&
+          args[0] === "issue" &&
+          args[1] === "comment" &&
+          args[2] === "2" &&
+          args[3] === "--body" &&
+          args[4] === "Linked PR: #77",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not auto-create PR when --no-ensure-pr is provided", async () => {
+    const postflightPath = path.join(tempDir, "no-ensure-pr-postflight.json");
+    writeFileSync(
+      postflightPath,
+      JSON.stringify(
+        {
+          version: 1,
+          meta: {
+            timestamp: "2026-02-13T00:00:00.000Z",
+            actor: "agent",
+            mode: "cli",
+          },
+          work: {
+            issue_id: 2,
+            branch: "issue-2-example",
+            base_branch: "main",
+          },
+          checks: {
+            tests: {
+              ran: true,
+              result: "pass",
+            },
+          },
+          tracker_updates: [{ type: "comment_append", body: "Done." }],
+          next_actions: ["Merge branch."],
+          risks: {
+            summary: "Low risk.",
+            rollback_plan: "Revert commit.",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
+      if (args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]" };
+      }
+      return { stdout: "" };
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--no-ensure-pr", "--skip-branch-cleanup"]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(
+      execaMock.mock.calls.some(
+        ([cmd, args]) => cmd === "gh" && Array.isArray(args) && args[0] === "pr" && args[1] === "create",
+      ),
+    ).toBe(false);
+  });
+
+  it("skips auto-create PR when branch equals base branch", async () => {
+    const postflightPath = path.join(tempDir, "same-branch-postflight.json");
+    writeFileSync(
+      postflightPath,
+      JSON.stringify(
+        {
+          version: 1,
+          meta: {
+            timestamp: "2026-02-13T00:00:00.000Z",
+            actor: "agent",
+            mode: "cli",
+          },
+          work: {
+            issue_id: 2,
+            branch: "main",
+            base_branch: "main",
+          },
+          checks: {
+            tests: {
+              ran: true,
+              result: "pass",
+            },
+          },
+          tracker_updates: [{ type: "comment_append", body: "Done." }],
+          next_actions: ["Merge branch."],
+          risks: {
+            summary: "Low risk.",
+            rollback_plan: "Revert commit.",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const execaMock = vi.fn(async (_cmd: string, args: string[]) => {
+      if (args[0] === "pr" && args[1] === "list") {
+        return { stdout: "[]" };
+      }
+      return { stdout: "" };
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const program = createProgram(execaMock as never);
+    await program.parseAsync(["node", "vibe", "postflight", "--file", postflightPath, "--apply", "--skip-branch-cleanup"]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(
+      execaMock.mock.calls.some(
+        ([cmd, args]) => cmd === "gh" && Array.isArray(args) && args[0] === "pr" && args[1] === "create",
+      ),
+    ).toBe(false);
   });
 
   it("rejects non-numeric issue_id before applying updates", async () => {
@@ -234,7 +412,7 @@ describe.sequential("cli postflight --apply", () => {
         "--body",
         "Fixes #2",
       ],
-      { stdio: "inherit" },
+      { stdio: "pipe" },
     );
     expect(execaMock).toHaveBeenNthCalledWith(
       3,
@@ -330,7 +508,7 @@ describe.sequential("cli postflight --apply", () => {
         "--body",
         "Fixes #2",
       ],
-      { stdio: "inherit" },
+      { stdio: "pipe" },
     );
     expect(execaMock).toHaveBeenNthCalledWith(
       3,


### PR DESCRIPTION
## Summary
- Issue: #112 feat(postflight): auto-open PR on --apply when branch has no open PR
- Branch: `codex/issue-112-postflight-ensure-pr`
- Issue URL: https://github.com/lucasgday/vibe-backlog/issues/112

## Architecture decisions
- Scope this PR to issue #112 (`feat(postflight): auto-open PR on --apply when branch has no open PR`) on branch `codex/issue-112-postflight-ensure-pr` in `pr-open` mode.
- Derived from changed files (2): profile=`code+tests`, modules=[cli, tests, tracker], sample=`src/cli-program.ts`, `tests/cli-postflight.test.ts`.
- Connect implementation paths and adjacent test updates so reviewers can trace behavior changes to coverage in one pass.

## Why these decisions were made
- Tailor this rationale to issue #112 (`feat(postflight): auto-open PR on --apply when branch has no open PR`) on `codex/issue-112-postflight-ensure-pr`: profile=`code+tests`, modules=[cli, tests, tracker], evidence=`src/cli-program.ts`, `tests/cli-postflight.test.ts`, themes=pr, review, tracker, postflight, labels=enhancement, module:cli, module:tracker, status:backlog.
- Mixed code+tests changes need a rationale that links behavior paths and tests in `src/cli-program.ts`, `tests/cli-postflight.test.ts`; a generic template cannot express this mapping.
- No validation or review summary signals were provided to the generator, so the rationale limits itself to issue/diff evidence.

## Alternatives considered / rejected
- Reuse one static alternatives section across all PRs: rejected for this diff (profile=`code+tests`, modules=[cli, tests, tracker], evidence=`src/cli-program.ts`, `tests/cli-postflight.test.ts`).
- Split code and tests into unrelated narratives: rejected because `src/cli-program.ts`, `tests/cli-postflight.test.ts` needs one cohesive behavior+verification explanation.
- Claim evidence not present in the signals (sample `src/cli-program.ts`, `tests/cli-postflight.test.ts`): rejected to keep rationale deterministic and auditable.

Fixes #112